### PR TITLE
respecting locale collate order in arrange. closes #325

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,10 @@
 
 * data frames and matrices as column of data frame processed by verbs 
   generates an error (#602). 
+  
+* The implementation of `OrderVisitor` for character vectors now honours 
+  locale ordering, using a callback to R to sort the strings. This affects
+  `arrange` and `order_` (#325)
 
 # dplyr 0.3.0.1
 

--- a/R/manip.r
+++ b/R/manip.r
@@ -140,12 +140,6 @@ transmute_.default <- function(.data, ..., .dots) {
 #'
 #' Use \code{\link{desc}} to sort a variable in descending order.
 #'
-#' @section Locales:
-#'
-#' Note that for local data frames, the ordering is done in C++ code which
-#' does not have access to the local specific ordering usually done in R.
-#' This means that strings are ordered as if in the C locale.
-#'
 #' @export
 #' @inheritParams filter
 #' @param ... Comma separated list of unquoted variable names. Use

--- a/inst/include/dplyr/Order.h
+++ b/inst/include/dplyr/Order.h
@@ -18,8 +18,9 @@ namespace dplyr {
         OrderVisitors( DataFrame data ) : 
             visitors(data.size()), n(data.size()), nrows( data.nrows() )
         {
-            for( int i=0; i<n; i++)
+            for( int i=0; i<n; i++){
                 visitors[i]  = order_visitor( data[i], true );
+            }
         } 
         
         OrderVisitors( DataFrame data, CharacterVector names ) : 

--- a/inst/include/dplyr/OrderVisitorImpl.h
+++ b/inst/include/dplyr/OrderVisitorImpl.h
@@ -55,6 +55,38 @@ namespace dplyr {
     private: 
         VECTOR vec ;    
     } ;
+    
+    template <bool ascending>
+    class StringOrderVisitor : public OrderVisitor {
+    public:
+        typedef OrderVectorVisitorImpl<INTSXP, ascending, IntegerVector> IntegerOrderVisitor ; 
+        
+        StringOrderVisitor( const CharacterVector& data_ ) : data(data_), visitor(orders(data)) {}
+        
+        inline bool equal(int i, int j) const {
+            return visitor.equal(i,j) ;    
+        }
+        
+        inline bool before(int i, int j) const {
+            return visitor.before(i,j) ;    
+        }
+        
+        inline SEXP get() {
+            return data ;    
+        }
+        
+    private:
+        
+        
+        inline IntegerVector orders( const CharacterVector strings ) {
+            Language call( "match", data, Language("sort", data) ) ;
+            return Rf_eval( call, R_GlobalEnv ) ;
+        }
+        
+        CharacterVector data ;
+        IntegerOrderVisitor visitor ;
+        
+    } ;
 
     inline OrderVisitor* order_visitor( SEXP vec, bool ascending ){
         if( ascending ){
@@ -62,7 +94,7 @@ namespace dplyr {
                 case INTSXP:  return new OrderVectorVisitorImpl<INTSXP , true, Vector<INTSXP > >( vec ) ;
                 case REALSXP: return new OrderVectorVisitorImpl<REALSXP, true, Vector<REALSXP> >( vec ) ;
                 case LGLSXP:  return new OrderVectorVisitorImpl<LGLSXP , true, Vector<LGLSXP > >( vec ) ;
-                case STRSXP:  return new OrderVectorVisitorImpl<STRSXP , true, Vector<STRSXP > >( vec ) ;
+                case STRSXP:  return new StringOrderVisitor<true>( vec ) ;
                 case CPLXSXP:  return new OrderVectorVisitorImpl<CPLXSXP , true, Vector<CPLXSXP > >( vec ) ;
                 default: break ;
             }
@@ -71,7 +103,7 @@ namespace dplyr {
                 case INTSXP:  return new OrderVectorVisitorImpl<INTSXP , false, Vector<INTSXP > >( vec ) ;
                 case REALSXP: return new OrderVectorVisitorImpl<REALSXP, false, Vector<REALSXP> >( vec ) ;
                 case LGLSXP:  return new OrderVectorVisitorImpl<LGLSXP , false, Vector<LGLSXP > >( vec ) ;
-                case STRSXP:  return new OrderVectorVisitorImpl<STRSXP , false, Vector<STRSXP > >( vec ) ;
+                case STRSXP:  return new StringOrderVisitor<false>( vec ) ;
                 case CPLXSXP:  return new OrderVectorVisitorImpl<CPLXSXP , false, Vector<CPLXSXP > >( vec ) ;
                 default: break ;
             }

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -144,3 +144,22 @@ test_that("arrange handles complex vectors", {
   
 })
 
+test_that("arrange respects locale ordering (#325)", {
+  old <- Sys.getlocale( "LC_COLLATE" )
+  Sys.setlocale( "LC_COLLATE", "fr_FR.UTF-8" )  
+  a <- data_frame( Name = c("IODOHIPPURATE DE SODIUM [131 I]", 
+    "IODOHIPPURATE [123-I] DE SODIUM",
+    "IODURE DE POTASSIUM", "IODURE DE POTASSIUM", "IODURE [123 I] DE SODIUM",
+    "IODURE [131 I] DE SODIUM", "IODURE [131 I] DE SODIUM POUR THERAPIE"
+  )) 
+  res_dplyr <- arrange( a, Name )
+  res_R     <- a[ order(a$Name), , drop = FALSE ]
+  expect_equal( res_dplyr$Name, res_R$Name )
+  
+  res_dplyr <- arrange( a, desc(Name) )
+  res_R     <- a[ order(a$Name, decreasing=TRUE), , drop = FALSE ]
+  expect_equal( res_dplyr$Name, res_R$Name )
+  
+  Sys.setlocale( "LC_COLLATE", old )
+})
+


### PR DESCRIPTION
The idea here is that instead of using internal ordering with the C locale, etc ... we make a callback to R to match strings with an integer vector of their order, i.e. with `match( x, sort(x) )` and then we use those numbers in the internal algorithm. 

There's a test based on the data from #325 

The drawback obviously is that we have to pay for `sort` and `match` but at least we do it just once per character vector. 

I'll let you decide @hadley if it is worth it, and so merge this PR. I think it is better like this. 