### PR TITLE
add_rownames() updated

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -142,10 +142,7 @@ as_data_frame <- function(x) {
 #'   print() %>%
 #'   add_rownames()
 add_rownames <- function(df, var = "rowname") {
-  stopifnot(is.data.frame(df))
-
-  df[[var]] <- rownames(df)
-  rownames(df) <- NULL
-
-  df
+  assert_that(is.data.frame(df), is.string(var))
+  rowname_df <- setNames(data_frame(rownames(df)), var)
+  cbind(rowname_df, df)
 }


### PR DESCRIPTION
1. I have added se and nse versions of `add_rownames()`: for consistency, where possible I think all functions in dplyr should offer this functionality.

2. I have coded it such that the rowname column is prepended to the data frame. I think more often than not this is where the user would expect this column to be placed. 