### PR TITLE
Add .id argument to bind_rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,10 @@ Until now, dplyr's support for non-UTF8 encodings has been rather shaky. This re
   cleaning you no longer need to convert lists to data frames, but can
   instead feed them to `bind_rows()` directly.
 
+* `bind_rows()` gains a `.id` argument. When supplied, it creates a
+  new column of identifiers that links each row to its original data
+  frame (#1337, @lionel-).
+
 * `bind_rows()` respects the `ordered` attribute of factors (#1112), and
   does better at comparing `POSIXct`s (#1125). The `tz` attribute is ignored
   when determining if two `POSIXct` vectors are comparable. If the `tz` of

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -38,8 +38,8 @@ between <- function(x, left, right) {
 }
 
 #' @export
-rbind_all <- function(dots) {
-    .Call('dplyr_rbind_all', PACKAGE = 'dplyr', dots)
+rbind_all <- function(dots, id = NULL) {
+    .Call('dplyr_rbind_all', PACKAGE = 'dplyr', dots, id)
 }
 
 rbind_list__impl <- function(dots) {

--- a/R/rbind.r
+++ b/R/rbind.r
@@ -18,6 +18,14 @@
 #'   frames must have the same number of rows. To match by value, not
 #'   position, see \code{left_join} etc. When row-binding, columns are
 #'   matched by name, and any values that don't match will be filled with NA.
+#' @param .id Data frames identifier.
+#'
+#'   When \code{.id} is supplied, a new column of identifiers is
+#'   created to link each row to its original data frame. The labels
+#'   are taken from the named arguments to \code{bind_rows()}. When a
+#'   list of data frames is supplied, the labels are taken from the
+#'   names of the list. If no names are found a numeric sequence is
+#'   used instead.
 #' @return \code{bind_rows} and \code{bind_cols} always return a \code{tbl_df}
 #' @aliases rbind_all rbind_list
 #' @examples
@@ -29,6 +37,11 @@
 #' # Or a single argument containing a list of data frames
 #' bind_rows(list(one, two))
 #' bind_rows(split(mtcars, mtcars$cyl))
+#'
+#' # When you supply a column name with the `.id` argument, a new
+#' # column is created to link each row to its original data frame
+#' bind_rows(list(a = one, b = two), .id = "id")
+#' bind_rows("group 1" = one, "group 2" = two, .id = "groups")
 #'
 #' # Columns don't need to match when row-binding
 #' bind_rows(data.frame(x = 1:3), data.frame(y = 1:4))
@@ -54,12 +67,31 @@ NULL
 
 #' @export
 #' @rdname bind
-bind_rows <- function(x, ...) {
-  if (is.list(x) && !is.data.frame(x) && !length(list(...)) ) {
-    rbind_all(x)
-  } else {
-    rbind_all(list(x, ...))
+bind_rows <- function(..., .id = NULL) {
+  dots <- list(...)
+  if (is.list(dots[[1]]) &&
+        !is.data.frame(dots[[1]]) &&
+        !length(dots[-1])) {
+    x <- dots[[1]]
   }
+  else {
+    x <- dots
+  }
+
+  if (!is.null(.id)) {
+    if (!(is.character(.id) && length(.id) == 1)) {
+      stop(".id is not a string", call. = FALSE)
+    }
+    names(x) <- names(x) %||% seq_along(x)
+    if (any(is.na(names(x)))) {
+      warning("Some ID labels are missing", call. = FALSE)
+    }
+    if (any(na.omit(names(x) == ""))) {
+      warning("Some ID labels are empty", call. = FALSE)
+    }
+  }
+
+  rbind_all(x, .id)
 }
 
 #' @export

--- a/inst/include/tools/DotsOf.h
+++ b/inst/include/tools/DotsOf.h
@@ -67,6 +67,10 @@ namespace Rcpp {
             return data.size();
         }
 
+        inline int names() const{
+            return data.names();
+        }
+
     private:
         List data ;
 

--- a/man/bind.Rd
+++ b/man/bind.Rd
@@ -9,13 +9,22 @@
 \alias{rbind_list}
 \title{Efficiently bind multiple data frames by row and column.}
 \usage{
-bind_rows(x, ...)
+bind_rows(..., .id = NULL)
 
 bind_cols(x, ...)
 
 combine(x, ...)
 }
 \arguments{
+\item{.id}{Data frames identifier.
+
+  When \code{.id} is supplied, a new column of identifiers is
+  created to link each row to its original data frame. The labels
+  are taken from the named arguments to \code{bind_rows()}. When a
+  list of data frames is supplied, the labels are taken from the
+  names of the list. If no names are found a numeric sequence is
+  used instead.}
+
 \item{x,...}{Data frames to combine.
 
   You can either supply one data frame per argument, or a list of
@@ -49,6 +58,11 @@ bind_rows(one, two)
 # Or a single argument containing a list of data frames
 bind_rows(list(one, two))
 bind_rows(split(mtcars, mtcars$cyl))
+
+# When you supply a column name with the `.id` argument, a new
+# column is created to link each row to its original data frame
+bind_rows(list(a = one, b = two), .id = "id")
+bind_rows("group 1" = one, "group 2" = two, .id = "groups")
 
 # Columns don't need to match when row-binding
 bind_rows(data.frame(x = 1:3), data.frame(y = 1:4))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -76,13 +76,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // rbind_all
-List rbind_all(List dots);
-RcppExport SEXP dplyr_rbind_all(SEXP dotsSEXP) {
+List rbind_all(List dots, SEXP id);
+RcppExport SEXP dplyr_rbind_all(SEXP dotsSEXP, SEXP idSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
     Rcpp::traits::input_parameter< List >::type dots(dotsSEXP);
-    __result = Rcpp::wrap(rbind_all(dots));
+    Rcpp::traits::input_parameter< SEXP >::type id(idSEXP);
+    __result = Rcpp::wrap(rbind_all(dots, id));
     return __result;
 END_RCPP
 }

--- a/tests/testthat/test-rbind.r
+++ b/tests/testthat/test-rbind.r
@@ -247,3 +247,24 @@ test_that("bind handles POSIXct of different tz ", {
   expect_equal( attr(res$date, "tzone"), "UTC" )
 
 })
+
+test_that("bind_rows() creates a column of identifiers (#1337)", {
+  data1 <- mtcars[c(2, 3), ]
+  data2 <- mtcars[1, ]
+
+  out <- bind_rows(data1, data2, .id = "col")
+  out_list <- bind_rows(list(data1, data2), .id = "col")
+  expect_equal(names(out)[12], "col")
+  expect_equal(out$col, c("1", "1", "2"))
+  expect_equal(out_list$col, c("1", "1", "2"))
+
+  out_labelled <- bind_rows(one = data1, two = data2, .id = "col")
+  out_list_labelled <- bind_rows(list(one = data1, two = data2), .id = "col")
+  expect_equal(out_labelled$col, c("one", "one", "two"))
+  expect_equal(out_list_labelled$col, c("one", "one", "two"))
+
+  list_missing <- list(data1, data2)
+  names(list_missing) <- c(NA, "two")
+  expect_warning(bind_rows(list_missing, .id = "col"))
+  expect_warning(bind_rows(list(data1, two = data2), .id = "col"))
+})


### PR DESCRIPTION
This makes row_binds append an identifier column when the `.id` argument is supplied.

This is useful for the common use case of combining data frames to be used for example by ggplot2. Best used with lowliner :-)

```
fits <- list(lm(disp ~ cyl, mtcars), lm(disp ~ mpg, mtcars)) %>%
  map(broom::tidy) %>%
  bind_rows(.id = "model")

## > + Source: local data frame [4 x 6]
##
##          term estimate std.error statistic    p.value      id
## 1 (Intercept) -156.609   35.1805   -4.4516 1.0902e-04 model 1
## 2         cyl   62.599    5.4693   11.4455 1.8028e-12 model 1
## 3 (Intercept)  580.884   41.7401   13.9167 1.2634e-14 model 2
## 4         mpg  -17.429    1.9925   -8.7472 9.3803e-10 model 2
```