### PR TITLE
Properly remove cluster in stop_cluster

### DIFF
--- a/R/cluster.R
+++ b/R/cluster.R
@@ -39,7 +39,7 @@ set_cluster <- function(x) {
 stop_cluster <- function() {
   if (has_cluster()) {
     stopCluster(cluster_env$cluster)
-    cluster_env$cluster <- NULL
+    rm("cluster", envir = cluster_env)
   }
 
   invisible()


### PR DESCRIPTION
I believe you need to remove the cluster in `cluster_env` rather than setting it to `NULL` because you use `exists` to check if the clusters have been initialized or not in `has_cluster`.