### PR TITLE
translation of plyr::ddply

### DIFF
--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -408,7 +408,7 @@ Compared to plyr:
 
 * it provides a better thought out set of joins
 
-* it only provides tools for working with data frames (e.g. most of dplyr is equivalent to `ddply()` + various functions, `do()` is equivalent to `dlply()`)
+* it only provides tools for working with data frames (e.g. most of dplyr is equivalent to `ddply()` + various functions, `do()` is equivalent to `dlply()`. For example `ddply(iris, .(Species),head)` is equivalent to `iris %>% group_by(Species) %>% do(head(.))`)
 
 Compared to virtual data frame approaches:
 


### PR DESCRIPTION
This statement "most of dplyr is equivalent to ddply()[...]" was slightly misleading for me. I took me a while to realise that ddply can also be replaced by do() in some cases. After a couple of months of using dplyr, I realised this today while converting a function that returns a data frame, calculated on a window for each country (GDP deflator by country).

This iris example might be best placed in a another page on translating plyr statement into dplyr.  But this introduction vignette is probably the first place most people will look at.