### PR TITLE
Hive does not accept table names that begin with a "_".

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -114,7 +114,7 @@ unique_name <- local({
 
   function() {
     i <<- i + 1
-    paste0("_W", i)
+    paste0("xW", i)
   }
 })
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HIVE-6431
Switch to using "x" as the prefix for unique_name().

I've started work on a Hive backend for dplyr that is working well so far. I'll be staging that for pull soon. This is a simple change that seems innocuous and is required by Hive due to its restrictions on tables and variables starting with an underscore.