### PR TITLE
Add read from .sql file functionality

### DIFF
--- a/R/sql-escape.r
+++ b/R/sql-escape.r
@@ -51,7 +51,16 @@
 #' rounder <- sql_variant(sql_translator(round = sql_round, .parent = base_agg))
 #' translate_sql(round(X), variant = rounder)
 #' translate_sql(round(X, 5), variant = rounder)
-sql <- function(x) {
+sql <- function(x = "", file = NULL) {
+  if (!missing(file)) {
+    if (!file.exists(file)) {
+      stop("File does not exist", call. = FALSE)
+    }
+    x <- paste(readLines(file, warn=F), collapse="\n")
+  }
+  if (grepl("\\.sql|\\.txt", x)) {
+    stop("Is this a file? Use file= argument", call. = FALSE)
+  }
   structure(x, class = c("sql", "character"))
 }
 


### PR DESCRIPTION
For those times when explicitly writing out a full SQL query is unavoidable, this is is a nice way of at least avoiding long quoted SQL _query strings_ in the chain. Keep a separate file/tab open where all the SQL goes (and is syntax highlighted). Then source it into your R script, like so:

`results <- tbl(my_conn, sql(file="my_query.sql")) %>% collect()`