### PR TITLE
Add mapping for ifelse <-> if in MySQL

### DIFF
--- a/R/src-mysql.r
+++ b/R/src-mysql.r
@@ -125,6 +125,7 @@ src_translate_env.src_mysql <- function(x) {
   sql_variant(
     base_scalar,
     sql_translator(.parent = base_agg,
+      ifelse = sql_prefix("if"),
       n = function() sql("count(*)"),
       sd =  sql_prefix("stddev_samp"),
       var = sql_prefix("var_samp"),


### PR DESCRIPTION
Lets you do the following:

    my_db <- src_mysql('test')
    copy_to(my_db, iris)

    myiris <- tbl(my_db, 'iris')
    myiris %>%
        mutate(is_setosa = ifelse(Species == 'setosa', 'setosa', 'nope')) %>%
        group_by(is_setosa) %>%
        tally
