### PR TITLE
x -> con to be consistent with rest of the example

### DIFF
--- a/vignettes/new-sql-backend.Rmd
+++ b/vignettes/new-sql-backend.Rmd
@@ -42,7 +42,7 @@ Next, implement a method for `src_desc()` that briefly describes the source:
 
 ```{r}
 #' @export
-src_desc.src_postgres <- function(x) {
+src_desc.src_postgres <- function(con) {
   info <- dbGetInfo(con)
   host <- if (info$host == "") "localhost" else info$host
 


### PR DESCRIPTION
The argument x in the function was not referenced and the variable con was used in the body of the function but not an argument. The intention was for the argument to be called con.