### PR TITLE
fix 'by=' statement in dplyr for dt_subset issue #883

### DIFF
--- a/R/utils-dt.R
+++ b/R/utils-dt.R
@@ -14,7 +14,8 @@ dt_subset <- function(dt, i, j, env = parent.frame(), sd_cols = NULL) {
   if (missing(j)) {
     call <- substitute(`_dt`[i], args)
   } else {
-    call <- substitute(`_dt`[i, j, by = `_vars`], args)
+    args$groupings <- lazyeval::make_call(quote(list), env$`_vars`)$expr
+    call <- substitute(`_dt`[i, j, by = groupings], args)
     call$.SDcols = sd_cols
   }
   # print(call)

--- a/R/utils-dt.R
+++ b/R/utils-dt.R
@@ -14,7 +14,8 @@ dt_subset <- function(dt, i, j, env = parent.frame(), sd_cols = NULL) {
   if (missing(j)) {
     call <- substitute(`_dt`[i], args)
   } else {
-    args$groupings <- lazyeval::make_call(quote(list), env$`_vars`)$expr
+    vars_tick <- sprintf("`%s`", env$`_vars`)
+    args$groupings <- lazyeval::make_call(quote(list), vars_tick)$expr
     call <- substitute(`_dt`[i, j, by = groupings], args)
     call$.SDcols = sd_cols
   }


### PR DESCRIPTION
Address issue #883 

Please see [my comment there](https://github.com/hadley/dplyr/issues/883#issuecomment-75350617)

[UPDATE: Issue is fixed in latest commit]

While this technically fixes the problem, `data.table` seems to have a bug where it drops everything after the function name.

```{r}
d> set.seed(42)
d> test.data <-
  data.frame(
    x1 = rnorm(100),
    x2 = rnorm(100),
    y = rnorm(100) )
d> data.table(test.data) %>%
+   group_by(round(x1,2), round(x2,2)) %>%
+   summarise(mean = mean(y))
Source: local data table [100 x 3]
Groups: round(x1, 2)

   round round.1       mean
1   1.37    1.20 -2.0009292
2  -0.56    1.04  0.3337772
3   0.36   -1.00  1.1713251
4   0.63    1.85  2.0595392
5   0.40   -0.67 -1.3768616
6  -0.11    0.11 -1.1508556
7   1.51   -0.42 -0.7058214
8  -0.09   -0.12 -1.0540558
9   2.02    0.19 -0.6457437
10 -0.06    0.12 -0.1853780
..   ...     ...        ...
```

Any suggestions on the "right" way to fix this?


Thanks!

Harold