### PR TITLE
Displaying names of duplicated columns in error message

### DIFF
--- a/inst/include/dplyr/GroupedDataFrame.h
+++ b/inst/include/dplyr/GroupedDataFrame.h
@@ -5,8 +5,12 @@ namespace Rcpp {
     
     inline void check_valid_colnames( const DataFrame& df){
         CharacterVector names(df.names()) ;
-        if( any( duplicated(names) ).is_true() ){
-            stop("found duplicated column name") ;    
+        LogicalVector duplicatedNames = duplicated(names);
+        CharacterVector duplicates = names[duplicatedNames];
+        duplicates = unique(duplicated(duplicates));
+        if( any( duplicatedNames ).is_true() ){
+            std::string duplicatesString = as<std::string>(duplicates);
+            stop("found duplicated column name %s", duplicatesString) ;    
         }
     }
     

--- a/inst/include/dplyr/GroupedDataFrame.h
+++ b/inst/include/dplyr/GroupedDataFrame.h
@@ -6,11 +6,21 @@ namespace Rcpp {
     inline void check_valid_colnames( const DataFrame& df){
         CharacterVector names(df.names()) ;
         LogicalVector duplicatedNames = duplicated(names);
-        CharacterVector duplicates = names[duplicatedNames];
-        duplicates = unique(duplicated(duplicates));
+        CharacterVector duplicates = CharacterVector(sum(duplicatedNames));
+        int it = 0;
+        for(int i = 0; i < names.size(); i++) {
+            if (duplicatedNames[i]) {
+                duplicates[it] = names[i];
+                it++;
+            }
+        }
         if( any( duplicatedNames ).is_true() ){
-            std::string duplicatesString = as<std::string>(duplicates);
-            stop("found duplicated column name %s", duplicatesString) ;    
+            std::string s = "";
+            for (int i = 0; i < duplicates.size(); ++i) {
+                s.append(as<std::string>(duplicates[0]));
+                if(i < duplicates.size() - 1) s.append(", ");
+            }
+            stop("found duplicated column names: %s", s) ;    
         }
     }
     


### PR DESCRIPTION
As mentioned in #996, error message for duplicated column names only said
<code> Error: found duplicated column name </code>.
Added printing out a list of duplicated column names.