### PR TITLE
Fixed typo in new-sql-backend.Rmd

### DIFF
--- a/vignettes/new-sql-backend.Rmd
+++ b/vignettes/new-sql-backend.Rmd
@@ -23,7 +23,7 @@ See `?backend_sql` and `?backend_db` for a complete list of generics.
 
 ## Create the src object
 
-Start by creating a new src function to represent the backend. Assuming we're going to create a src for mssql, you'd call it `src_mssql()`, and you'd follow the pattern of an existing src. A simplified version of `src_postgres()` is show below:
+Start by creating a new src function to represent the backend. Assuming we're going to create a src for postgres, you'd call it `src_postgres()`, and you'd follow the pattern of an existing src. A simplified version of `src_postgres()` is show below:
 
 ```{r, eval = FALSE}
 src_postgres <- function(dbname = NULL, host = NULL, port = NULL, user = NULL,


### PR DESCRIPTION
`mysql` -> `postgres`