### PR TITLE
add parentheses to WHERE clause for complex conditions

### DIFF
--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -257,6 +257,11 @@ uses_window_fun <- function(x, tbl) {
 #' @export
 filter_.tbl_sql <- function(.data, ..., .dots) {
   dots <- lazyeval::all_dots(.dots, ...)
+  dots <- Map(function(d) {
+    expr <- sprintf("(%s)", deparse(d$expr))
+    lazyeval::as.lazy(expr, env = d$env)
+  }, dots)
+  dots <- lazyeval::all_dots(dots)
   input <- partial_eval(dots, .data)
 
   update(.data, where = c(.data$where, input))

--- a/tests/testthat/test-tbl-sql.r
+++ b/tests/testthat/test-tbl-sql.r
@@ -7,7 +7,31 @@ tbls <- temp_load(srcs, list(df = df))
 name <- tbls[[1]]$df$from
 
 test_that("can generate sql tbls with raw sql", {
-  
+
   raw <- lapply(srcs, function(x) tbl(x, build_sql("SELECT * FROM ", name)))
   expect_true(compare_tbls(raw, identity, ref = df))
+})
+
+test_that("complex filter condition for sqlite", {
+  tbl_sqlite <- tbls$sqlite$df
+  query <- tbl_sqlite %>%
+    filter(x <= 2) %>%
+    filter(x <= 1 || x >= 3)
+  df <- query %>% collect
+  expect_equal(nrow(df), 1)
+  expect_equal(df$x, 1)
+  expect_equal(df$y, 3)
+})
+
+test_that("complex filter condition for postgres", {
+  if(!is.null(tbls$postgres)) {
+    tbl_postgres <- tbls$postgres$df
+    query <- tbl_postgres %>%
+      filter(x <= 2) %>%
+      filter(x <= 1 || x >= 3)
+    df <- query %>% collect
+    expect_equal(nrow(df), 1)
+    expect_equal(df$x, 1)
+    expect_equal(df$y, 3)
+  }
 })


### PR DESCRIPTION
When I wrote a code like below, I encountered an unintended result.

```r
srcs <- temp_srcs("sqlite")
df <- data.frame(x = 1:3, y = 3:1)
tbls <- dplyr:::temp_load(srcs, list(df = df))

temp_tbl <- tbls$sqlite$df
q <- temp_tbl %>% 
  filter(x <= 2) %>%
  filter(x <= 1 || x >= 3)
df <- q %>% collect
df
```

```
  x y
1 1 3
2 3 1
```

The cause is that the `filter` function merely concatenates the conditions.

```r
q$query
```

```
<Query> SELECT "x", "y"
FROM "offffmlffk"
WHERE "x" <= 2.0 AND "x" <= 1.0 OR "x" >= 3.0
<SQLiteConnection>
```

I expect the WHERE clause to become the below.

```
WHERE ("x" <= 2.0) AND ("x" <= 1.0 OR "x" >= 3.0)
```
