### PR TITLE
Add postgres update and upsert

### DIFF
--- a/R/src-postgres.r
+++ b/R/src-postgres.r
@@ -179,6 +179,6 @@ db_insert_into.PostgreSQLConnection <- function(con, table, values, ...) {
   rows <- apply(col_mat, 1, paste0, collapse = ", ")
   values <- paste0("(", rows, ")", collapse = "\n, ")
 
-  sql <- build_sql("INSERT INTO ", ident(table), " VALUES ", sql(values))
+  sql <- build_sql("INSERT INTO ", sql(paste0(table, collapse='.')), " VALUES ", sql(values))
   dbGetQuery(con, sql)
 }

--- a/R/src-postgres.r
+++ b/R/src-postgres.r
@@ -169,6 +169,10 @@ db_explain.PostgreSQLConnection <- function(con, sql, format = "text", ...) {
 
 #' @export
 db_insert_into.PostgreSQLConnection <- function(con, table, values, ...) {
+
+  if (nrow(values) == 0)
+    return(NULL)
+  
   cols <- lapply(values, escape, collapse = NULL, parens = FALSE, con = con)
   col_mat <- matrix(unlist(cols, use.names = FALSE), nrow = nrow(values))
 


### PR DESCRIPTION
Add update and upsert functions for postgres connections. I haven't found a commonly accepted practice to updating or upserting many records into a PostgreSQL database from R. I can understand if this type of functionality should be rejected here and exists in RPostgres package. It was just not clear in its documentation that this functionality exists in via a parameterized query with dbBind or another function. The other alternative solution I've seen recommends repeating the query for each record to update, which doesn't seem as efficient as one large query as I've implemented 

Link to stackoverflow solution: http://stackoverflow.com/questions/15099507/update-table-in-postgresql-database-through-r

Thanks for your consideration.