### PR TITLE
Fixed issue 926 (problems with escaping table names for SQLite databases)

### DIFF
--- a/R/src-sqlite.r
+++ b/R/src-sqlite.r
@@ -149,5 +149,6 @@ db_insert_into.SQLiteConnection <- function(con, table, values, ...) {
   assert_that(is.string(table), is.data.frame(values))
   valStr <- paste(rep("?", ncol(values)), collapse = ",")
   sql <- build_sql("insert into ", ident(table), " values (", sql(valStr), ")")
-  RSQLite::dbSendPreparedQuery(con, sql, bind.data = values)
+  rs <- RSQLite::dbSendPreparedQuery(con, sql, bind.data = values)
+  dbClearResult(rs)
 }

--- a/R/src-sqlite.r
+++ b/R/src-sqlite.r
@@ -127,7 +127,7 @@ src_translate_env.src_sqlite <- function(x) {
 
 #' @export
 db_query_fields.SQLiteConnection <- function(con, sql, ...) {
-  rs <- DBI::dbSendQuery(con, paste0("SELECT * FROM ", sql))
+  rs <- DBI::dbSendQuery(con, build_sql("SELECT * FROM ", sql))
   on.exit(DBI::dbClearResult(rs))
 
   names(fetch(rs, 0L))
@@ -146,5 +146,8 @@ db_explain.SQLiteConnection <- function(con, sql, ...) {
 
 #' @export
 db_insert_into.SQLiteConnection <- function(con, table, values, ...) {
-  DBI::dbWriteTable(con, table, values, append = TRUE, row.names = FALSE)
+  assert_that(is.string(table), is.data.frame(values))
+  valStr <- paste(rep("?", ncol(values)), collapse = ",")
+  sql <- build_sql("insert into ", ident(table), " values (", sql(valStr), ")")
+  RSQLite::dbSendPreparedQuery(con, sql, bind.data = values)
 }


### PR DESCRIPTION
Fixed issues described with SQLite at https://github.com/hadley/dply/issues/926 by creating new function for db_insert_into that supports escaping (unlike the current DBI::dbWriteTable that was used) and using build_sql rather than paste0 within db_query_fields.

This was also raised at http://stackoverflow.com/questions/28132697/bracket-escaped-table-names-with-dplyr