### PR TITLE
Fix typo in dplyr.R documentation

### DIFF
--- a/R/dplyr.r
+++ b/R/dplyr.r
@@ -1,7 +1,7 @@
 #' dplyr: a grammar of data manipulation
 #'
 #' dplyr provides a flexible grammar of data manipulation. It's the next
-#' iteration of plyr, focussed on tools for working with data frames (hence the
+#' iteration of plyr, focused on tools for working with data frames (hence the
 #' \emph{d} in the name).
 #'
 #' It has three main goals:

--- a/man/dplyr.Rd
+++ b/man/dplyr.Rd
@@ -7,7 +7,7 @@
 \title{dplyr: a grammar of data manipulation}
 \description{
 dplyr provides a flexible grammar of data manipulation. It's the next
-iteration of plyr, focussed on tools for working with data frames (hence the
+iteration of plyr, focused on tools for working with data frames (hence the
 \emph{d} in the name).
 }
 \details{


### PR DESCRIPTION
"focussed" has been corrected to "focused."

Rd documentation has been regenerated accordingly using roxygen.