### PR TITLE
[proposal] ORDER BY in window functions should not be automatically assumed to be also the order of the full final result

### DIFF
--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -207,10 +207,10 @@ build_query <- function(x, limit = NULL) {
     # Don't use group_by - grouping affects window functions only
     group_by_sql <- NULL
 
-    # If the user requested ordering, ensuring group_by is included
+    # If the user does not use window functions, then order full results as requested
     # Otherwise don't, because that may make queries substantially slower
-    if (!is.null(x$order_by) && !is.null(x$group_by)) {
-      order_by_sql <- translate(c(x$group_by, x$order_by))
+    if (uses_window_fun(x$select, x)) {
+      order_by_sql <- NULL
     } else {
       order_by_sql <- translate(x$order_by)
     }


### PR DESCRIPTION
### Introduction
When `build_query` generates window functions with `OVER (PARTITION BY x ORDER BY y)`, the query builder then also automatically assumes that not just the partition but also the full final result needs to be ordered by `x` and `y` and thus, inserts an extra `ORDER BY x,y` at the end even though it was never requested. 

Problems with current behavior:
* This creates a significant performance hit for larger queries for no reason. (to the extent that otherwise doable queries become impossible to run). 
* it appears that it is not possible for the user to disable that behavior and remove the offending `ORDER BY x,y` (without modifying the library code).
* this does not appear to be an SQL requirement

### Details
Consider the following test code:
``` r
library(dplyr)

if (!has_lahman("postgres")) {
  stop("You need to have Lahman data installed")
}

salaries <- lahman_postgres() %>% tbl("Salaries")

salaries %>%
  group_by( teamID ) %>%
  arrange( salary ) %>%
  mutate( lower_salary = lag(salary)) %>%
  explain
```
This generates the following query:
```
SELECT "yearID", "teamID", "lgID", "playerID", "salary", "lower_salary"
FROM (SELECT "yearID", "teamID", "lgID", "playerID", "salary", LAG("salary", 1, NULL) OVER (PARTITION BY "teamID" ORDER BY "salary") AS "lower_salary"
FROM "Salaries"
ORDER BY "teamID", "salary") AS "_W1"
```

As can be seen `build_query` adds `ORDER BY "teamID", "salary"` at the end even though it was never specifically requested. 

For large datasets, that could be a large performance hit. As of now, there seems to be no way to disable that behavior.

### Proposed fix

This pull request:
* Disables inheriting the `order by` from inside window functions. (It can always be added by the user explicitly if needed).

For example, with this pull request, the above code produces:
```
SELECT "yearID", "teamID", "lgID", "playerID", "salary", "lower_salary"
FROM (SELECT "yearID", "teamID", "lgID", "playerID", "salary", LAG("salary", 1, NULL) OVER (PARTITION BY "teamID" ORDER BY "salary") AS "lower_salary"
FROM "Salaries") AS "_W1"
```
which is valid SQL and removes the final ORDER BY performance hit

If it is desired to have a particular full final result order, then the users always have the option to specify it explicitly.
``` r
salaries %>%
  group_by( teamID ) %>%
  arrange( salary ) %>%
  mutate( lower_salary = lag(salary)) %>%
  arrange( teamID, salary ) %>%
  explain
```
which generates
``` sql
SELECT "yearID", "teamID", "lgID", "playerID", "salary", "lower_salary"
FROM (SELECT "yearID", "teamID", "lgID", "playerID", "salary", LAG("salary", 1, NULL) OVER (PARTITION BY "teamID" ORDER BY "salary") AS "lower_salary"
FROM "Salaries") AS "_W1"
ORDER BY "teamID", "salary"
```
