### PR TITLE
added option `show_classes` for `print.tbl_df`

### DIFF
--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -104,10 +104,10 @@ as.data.frame.tbl_df <- function(x, row.names = NULL, optional = FALSE, ...) {
 
 #' @rdname dplyr-formatting
 #' @export
-print.tbl_df <- function(x, ..., n = NULL, width = NULL, show_classes = NULL) {
+print.tbl_df <- function(x, ..., n = NULL, m = NULL, width = NULL, show_classes = NULL) {
   cat("Source: local data frame ", dim_desc(x), "\n", sep = "")
   cat("\n")
-  print(trunc_mat(x, n = n, width = width, show_classes = show_classes))
+  print(trunc_mat(x, n = n, m = m, width = width, show_classes = show_classes))
 
   invisible(x)
 }

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -104,10 +104,10 @@ as.data.frame.tbl_df <- function(x, row.names = NULL, optional = FALSE, ...) {
 
 #' @rdname dplyr-formatting
 #' @export
-print.tbl_df <- function(x, ..., n = NULL, width = NULL) {
+print.tbl_df <- function(x, ..., n = NULL, width = NULL, show_classes = NULL) {
   cat("Source: local data frame ", dim_desc(x), "\n", sep = "")
   cat("\n")
-  print(trunc_mat(x, n = n, width = width))
+  print(trunc_mat(x, n = n, width = width, show_classes = show_classes))
 
   invisible(x)
 }

--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -35,7 +35,7 @@
 #' print(tbl_df(mtcars), n = 3, m = 1)
 #' print(tbl_df(mtcars), n = 100, m = 100)
 #'
-#' print(tbl_df(mtcars), show_classes = T)
+#' print(tbl_df(mtcars), show_classes = TRUE)
 #'
 #' @name dplyr-formatting
 NULL

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -2,7 +2,7 @@
   op <- options()
   op.dplyr <- list(
     dplyr.strict_sql = FALSE,
-    dplyr.print_min = 10L,
+    dplyr.print_min = 5L,
     dplyr.print_max = 20L
   )
   toset <- !(names(op.dplyr) %in% names(op))

--- a/man/dplyr-formatting.Rd
+++ b/man/dplyr-formatting.Rd
@@ -9,7 +9,7 @@
 \alias{trunc_mat}
 \title{Tools for describing matrices}
 \usage{
-\method{print}{tbl_df}(x, ..., n = NULL, width = NULL,
+\method{print}{tbl_df}(x, ..., n = NULL, m = NULL, width = NULL,
   show_classes = NULL)
 
 \method{print}{tbl_dt}(x, ..., n = NULL, width = NULL)
@@ -18,14 +18,20 @@
 
 dim_desc(x)
 
-trunc_mat(x, n = NULL, width = NULL, show_classes = NULL)
+trunc_mat(x, n = NULL, m = NULL, width = NULL, show_classes = NULL)
 }
 \arguments{
 \item{x}{Object to show.}
 
-\item{n}{Number of rows to show. If \code{NULL}, the default, will print
-all rows if less than option \code{dplyr.print_max}. Otherwise, will
-print \code{dplyr.print_min}}
+\item{n}{Number of top rows to show. If \code{NULL}, the default, will print
+all rows if less than option \code{dplyr.print_max}. Otherwise, will print
+\code{dplyr.print_min}. Setting \code{n} without setting \code{m} implies
+\code{m = 0}.}
+
+\item{m}{Number of bottom rows to show. If \code{NULL}, the default, will
+print all rows if less than option \code{dplyr.print_max}. Otherwise, will
+print \code{dplyr.print_min}. Setting \code{m} without setting \code{n}
+implies \code{n = 0}.}
 
 \item{width}{Width of text output to generate. This defaults to NULL, which
 means use \code{getOption("width")} and only display the columns that
@@ -34,7 +40,7 @@ override this default and always print all columns.}
 
 \item{show_classes}{If set to \code{TRUE}, the class short names will be
 printed under the column names. The default value can be overwritten by
-setting \code{option(dplyr.print_show_classes = TRUE)}}
+setting \code{option(dplyr.print_show_classes = TRUE)}.}
 }
 \description{
 Tools for describing matrices
@@ -44,11 +50,20 @@ dim_desc(mtcars)
 trunc_mat(mtcars)
 
 print(tbl_df(mtcars))
+
 print(tbl_df(mtcars), n = 1)
 print(tbl_df(mtcars), n = 3)
 print(tbl_df(mtcars), n = 100)
 
-print(tbl_df(mtcars), n = 100, show_classes = T)
+print(tbl_df(mtcars), m = 1)
+print(tbl_df(mtcars), m = 3)
+print(tbl_df(mtcars), m = 100)
+
+print(tbl_df(mtcars), n = 1, m = 3)
+print(tbl_df(mtcars), n = 3, m = 1)
+print(tbl_df(mtcars), n = 100, m = 100)
+
+print(tbl_df(mtcars), show_classes = T)
 }
 \keyword{internal}
 

--- a/man/dplyr-formatting.Rd
+++ b/man/dplyr-formatting.Rd
@@ -9,7 +9,8 @@
 \alias{trunc_mat}
 \title{Tools for describing matrices}
 \usage{
-\method{print}{tbl_df}(x, ..., n = NULL, width = NULL)
+\method{print}{tbl_df}(x, ..., n = NULL, width = NULL,
+  show_classes = NULL)
 
 \method{print}{tbl_dt}(x, ..., n = NULL, width = NULL)
 
@@ -17,7 +18,7 @@
 
 dim_desc(x)
 
-trunc_mat(x, n = NULL, width = NULL)
+trunc_mat(x, n = NULL, width = NULL, show_classes = NULL)
 }
 \arguments{
 \item{x}{Object to show.}
@@ -30,6 +31,10 @@ print \code{dplyr.print_min}}
 means use \code{getOption("width")} and only display the columns that
 fit on one screen. You can also set \code{option(dplyr.width = Inf)} to
 override this default and always print all columns.}
+
+\item{show_classes}{If set to \code{TRUE}, the class short names will be
+printed under the column names. The default value can be overwritten by
+setting \code{option(dplyr.print_show_classes = TRUE)}}
 }
 \description{
 Tools for describing matrices
@@ -42,6 +47,8 @@ print(tbl_df(mtcars))
 print(tbl_df(mtcars), n = 1)
 print(tbl_df(mtcars), n = 3)
 print(tbl_df(mtcars), n = 100)
+
+print(tbl_df(mtcars), n = 100, show_classes = T)
 }
 \keyword{internal}
 

--- a/man/n_distinct.Rd
+++ b/man/n_distinct.Rd
@@ -4,10 +4,12 @@
 \alias{n_distinct}
 \title{Efficiently count the number of unique values in a vector.}
 \usage{
-n_distinct(x)
+n_distinct(x, na_rm = FALSE)
 }
 \arguments{
 \item{x}{a vector of values}
+
+\item{na_rm}{if \code{TRUE} missing values don't count}
 }
 \description{
 This is a faster and more concise equivalent of \code{length(unique(x))}


### PR DESCRIPTION
Adding option `show_classes` for `print.tbl_df`
-----------------

I think being able to see classes directly would drastically increase my productivity and lower the chance of mistakes. Especially sometimes I need to distinguish between `character` and `factor`, or between `double` and `integer` etc. Plus, we have class names for omitted columns then why not the columns that are actually shown?

![image](https://cloud.githubusercontent.com/assets/4512709/8751420/f79aea40-2c7a-11e5-9ab3-12c198babaae.png)


Adding option `m` for `print.tbl_df`
------------------

Instead of printing the top 10 by default, I changed it to printing 5 top and 5 bottom. Users can set the added `m` option to change how many bottom rows to show. Now the option `dplyr.show_min` will dictate the default values of both `n` and `m`, and is set to `5`.

I made so that setting one of `n` or `m` without the other implies the other to be `0`. So the behavior of previous code `print(n=...)` will not change.

![image](https://cloud.githubusercontent.com/assets/4512709/8752772/837cb4ea-2c84-11e5-8ccc-f3777789f94b.png)

![image](https://cloud.githubusercontent.com/assets/4512709/8752787/9c0b9cb0-2c84-11e5-9c4b-441fbf5a8e97.png)

![image](https://cloud.githubusercontent.com/assets/4512709/8752794/a9458d00-2c84-11e5-8a79-df56a00b6fb1.png)

![image](https://cloud.githubusercontent.com/assets/4512709/8752805/bb66ad5c-2c84-11e5-822e-63b4742ba7e5.png)
