### PR TITLE
Sqlite escape revised fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,9 @@
 
 * `sum` issues a warning about integer overflow when used inside dplyr verbs (#1108). 
 
-* `filter` does not alter a named expression (#971). 
+* `filter` does not alter a named expression (#971).
+
+* `db_query_fields.SQLiteConnection` uses `build_sql` rather than `paste` (#926, @NikNakk)
 
 # dplyr 0.4.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 
 * `filter` does not alter a named expression (#971).
 
-* `db_query_fields.SQLiteConnection` uses `build_sql` rather than `paste` (#926, @NikNakk)
+* `db_query_fields.SQLiteConnection` uses `build_sql` rather than `paste0` (#926, @NikNakk)
 
 # dplyr 0.4.2
 

--- a/R/src-sqlite.r
+++ b/R/src-sqlite.r
@@ -146,9 +146,5 @@ db_explain.SQLiteConnection <- function(con, sql, ...) {
 
 #' @export
 db_insert_into.SQLiteConnection <- function(con, table, values, ...) {
-  assert_that(is.string(table), is.data.frame(values))
-  valStr <- paste(rep("?", ncol(values)), collapse = ",")
-  sql <- build_sql("INSERT INTO ", ident(table), " values (", sql(valStr), ")")
-  rs <- RSQLite::dbSendPreparedQuery(con, sql, bind.data = values)
-  dbClearResult(rs)
+  DBI::dbWriteTable(con, table, values, append = TRUE, row.names = FALSE)
 }

--- a/R/src-sqlite.r
+++ b/R/src-sqlite.r
@@ -127,7 +127,7 @@ src_translate_env.src_sqlite <- function(x) {
 
 #' @export
 db_query_fields.SQLiteConnection <- function(con, sql, ...) {
-  rs <- DBI::dbSendQuery(con, paste0("SELECT * FROM ", sql))
+  rs <- DBI::dbSendQuery(con, build_sql("SELECT * FROM ", sql))
   on.exit(DBI::dbClearResult(rs))
 
   names(fetch(rs, 0L))
@@ -146,5 +146,9 @@ db_explain.SQLiteConnection <- function(con, sql, ...) {
 
 #' @export
 db_insert_into.SQLiteConnection <- function(con, table, values, ...) {
-  DBI::dbWriteTable(con, table, values, append = TRUE, row.names = FALSE)
+  assert_that(is.string(table), is.data.frame(values))
+  valStr <- paste(rep("?", ncol(values)), collapse = ",")
+  sql <- build_sql("INSERT INTO ", ident(table), " values (", sql(valStr), ")")
+  rs <- RSQLite::dbSendPreparedQuery(con, sql, bind.data = values)
+  dbClearResult(rs)
 }


### PR DESCRIPTION
The necessary changes to `dbWriteTable` have been made in the current version of RSQLite. However, there still remains a problem with the `db_query_fields.SQLiteConnection` function which uses `paste0` rather than `build_sql`. This pull request has a fix for that minor outstanding issue which resolves the raised in issue #926.