### PR TITLE
summarize spelling for summarise_each as well

### DIFF
--- a/R/colwise.R
+++ b/R/colwise.R
@@ -50,6 +50,14 @@ summarise_each_ <- function(tbl, funs, vars) {
   summarise_(tbl, .dots = vars)
 }
 
+#' @rdname summarise_each
+#' @export
+summarize_each <- summarise_each
+
+#' @rdname summarise_each
+#' @export
+summarize_each_ <- summarise_each_
+
 #' @export
 summarise_each_q <- function(...) {
   .Deprecated("summarise_each_")


### PR DESCRIPTION
Please add these aliases as well, I default to summarize and get caught out when using summarise_each. 

Cheers, Mike. 