### PR TITLE
You forgot to replace dots() with lazy_dots() in mutate_each()

### DIFF
--- a/R/colwise.R
+++ b/R/colwise.R
@@ -59,7 +59,7 @@ summarise_each_q <- function(...) {
 #' @export
 #' @rdname summarise_each
 mutate_each <- function(tbl, funs, ...) {
-  mutate_each_(tbl, funs, dots(...))
+  mutate_each_(tbl, funs, lazyeval::lazy_dots(...))
 }
 
 #' @export
@@ -86,7 +86,7 @@ colwise_ <- function(tbl, calls, vars) {
 
   out <- vector("list", length(vars) * length(calls))
   dim(out) <- c(length(vars), length(calls))
-  
+
   vars <- enc2native(vars)
   for (i in seq_along(vars)) {
     for (j in seq_along(calls)) {


### PR DESCRIPTION
In the commit https://github.com/hadley/dplyr/commit/65aef3a99725cd8bdd70e936f56e61f95acbc500, `summarise_each()` was modified from

```r
summarise_each <- function(tbl, funs, ...) {
  env <- parent.frame()
  summarise_each_q(tbl, funs, dots(...), env)
}
```

to

```r
summarise_each <- function(tbl, funs, ...) {
  summarise_each_(tbl, funs, lazyeval::lazy_dots(...))
}
```

And `mutate_each()` was modified from

```r
mutate_each <- function(tbl, funs, ...) {
  env <- parent.frame()
  mutate_each_q(tbl, funs, dots(...), env)
}
```

to

```r
mutate_each <- function(tbl, funs, ...) {
  mutate_each_(tbl, funs, dots(...))
}
```

I think you forgot to replace `dots()` with `lazy_dots()` in `mutate_each()`.

This will cause the following problem.

```r
match_str <- "Width"
iris %>% mutate_each(funs(max), matches(match_str)) %>% head
```

```
Error in is.string(match) : object 'match_str' not found
```

This pull request is intended to solve this problem.
