### PR TITLE
Postgres: Add missing comma to build_sql call used translate paste()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -371,6 +371,9 @@ This is a minor release containing fixes for a number of crashes and issues iden
 
 ### Databases
 
+* Correct SQL generation for `paste()` when used with the collapse parameter
+  targeting a Postgres database. (@rbdixon, #1357)
+
 * The db backend system has been completely overhauled in order to make
   it possible to add backends in other packages, and to support a much
   wider range of databases. See `vignette("new-sql-backend")` for instruction

--- a/R/src-postgres.r
+++ b/R/src-postgres.r
@@ -135,7 +135,7 @@ src_translate_env.src_postgres <- function(x) {
       var = sql_prefix("var_samp"),
       all = sql_prefix("bool_and"),
       any = sql_prefix("bool_or"),
-      paste = function(x, collapse) build_sql("string_agg(", x, collapse, ")")
+      paste = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
     ),
     base_win
   )


### PR DESCRIPTION
```R
con = src_postgres()
data = copy_to(con, tbl_df( data.frame(l=LETTERS)), name = dplyr:::random_table_name() )
print( summarize(data, m=paste(l, collapse="/")))
```

The code above fails yielding:

```
Error in postgresqlExecStatement(conn, statement, ...) :
RS-DBI driver: (could not Retrieve the result : ERROR:  type "l" does not exist
LINE 2: FROM (SELECT string_agg("l"'/') AS "m"
```

Simply missing a comma. With this patch applied you get the expected:

```
Source: postgres 9.4.4 [gt5392c@localhost:5432/gt5392c]
From: <derived table> [?? x 1]
   m
1  A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/Q/R/S/T/U/V/W/X/Y/Z
..                                                 ...