### PR TITLE
Swap order of dim_names and met_name in as.tbl_cube

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,12 @@
 
 * When printing a grouped data frame the number of groups is now printed with thousands separators. (#1398)
 
+* Swap order of `dim_names` and `met_name` arguments in `as.tbl_cube`
+  (for `array`, `table` and `matrix`) for consistency with `tbl_cube` and
+  `as.tbl_cube.data.frame`. Also, the `met_name` argument to `as.tbl_cube.table`
+  now defaults to `"Freq"` for consistency with `as.data.frame.table`.
+  (@krlmlr, #1374).
+
 # dplyr 0.4.3
 
 ## Improved encoding support

--- a/R/tbl-cube.r
+++ b/R/tbl-cube.r
@@ -166,11 +166,10 @@ as.tbl_cube <- function(x, ...) UseMethod("as.tbl_cube")
 
 #' @export
 #' @rdname as.tbl_cube
-#' @param met_name a string to use as the name for the metric
 #' @param dim_names names of the dimesions. Defaults to the names of
+#' @param met_name a string to use as the name for the measure
 #'   the \code{\link{dimnames}}.
-as.tbl_cube.array <- function(x, met_name = deparse(substitute(x)),
-                               dim_names = names(dimnames(x)), ...) {
+as.tbl_cube.array <- function(x, dim_names = names(dimnames(x)), met_name = deparse(substitute(x)), ...) {
   force(met_name)
 
   dims <- dimnames(x)
@@ -191,7 +190,9 @@ undimname <- function(x) {
 
 #' @export
 #' @rdname as.tbl_cube
-as.tbl_cube.table <- as.tbl_cube.array
+as.tbl_cube.table <- function(x, dim_names = names(dimnames(x)), met_name = "Freq", ...) {
+  as.tbl_cube.array(x, dim_names = dim_names, met_name = met_name)
+}
 
 #' @export
 #' @rdname as.tbl_cube

--- a/man/as.tbl_cube.Rd
+++ b/man/as.tbl_cube.Rd
@@ -10,16 +10,17 @@
 \usage{
 as.tbl_cube(x, ...)
 
-\method{as.tbl_cube}{array}(x, met_name = deparse(substitute(x)),
-  dim_names = names(dimnames(x)), ...)
+\method{as.tbl_cube}{array}(x, dim_names = names(dimnames(x)),
+  met_name = deparse(substitute(x)), ...)
 
-\method{as.tbl_cube}{table}(x, met_name = deparse(substitute(x)),
-  dim_names = names(dimnames(x)), ...)
+\method{as.tbl_cube}{table}(x, dim_names = names(dimnames(x)),
+  met_name = "Freq", ...)
 
-\method{as.tbl_cube}{matrix}(x, met_name = deparse(substitute(x)),
-  dim_names = names(dimnames(x)), ...)
+\method{as.tbl_cube}{matrix}(x, dim_names = names(dimnames(x)),
+  met_name = deparse(substitute(x)), ...)
 
-\method{as.tbl_cube}{data.frame}(x, dim_names, ...)
+\method{as.tbl_cube}{data.frame}(x, dim_names = NULL,
+  met_name = guess_met(x), ...)
 }
 \arguments{
 \item{x}{an object to convert. Built in methods will convert arrays,
@@ -27,9 +28,9 @@ tables and data frames.}
 
 \item{...}{Passed on to individual methods; otherwise ignored.}
 
-\item{met_name}{a string to use as the name for the metric}
+\item{dim_names}{names of the dimesions. Defaults to the names of}
 
-\item{dim_names}{names of the dimesions. Defaults to the names of
+\item{met_name}{a string to use as the name for the measure
 the \code{\link{dimnames}}.}
 }
 \description{


### PR DESCRIPTION
- to make it consistent with the `tbl_cube` constructor
- to allow adding a `met_name` argument to `as.tbl_cube.data.frame` later

Also, the `met_name` argument to `as.tbl_cube.table` now defaults to `"Freq"` for consistency with `as.data.frame.table`.

This is a breaking change, but perhaps justified since
> `tbl_cube` support is currently experimental