### PR TITLE
descriptive error messages

### DIFF
--- a/R/select-vars.R
+++ b/R/select-vars.R
@@ -121,14 +121,14 @@ rename_vars <- function(vars, ...) {
 #' @rdname select_vars
 rename_vars_ <- function(vars, args) {
   if (any(names2(args) == "")) {
-    stop("All arguments to rename must be named.", call. = FALSE)
+    stop("All arguments to rename() must be named.", call. = FALSE)
   }
 
   args <- lazyeval::as.lazy_dots(args)
   is_name <- vapply(args, function(x) is.name(x$expr), logical(1))
   if (!all(is_name)) {
-    stop("Arguments to rename must be unquoted variable names. ",
-      "Arguments ", paste0(names(args)[!is_name], collapse =", "), " are not.",
+    stop("Arguments to rename() must be unquoted variable names. ",
+      "These arguments: {", paste0(names(args)[!is_name], collapse =", "), "} were not.",
       call. = FALSE
     )
   }


### PR DESCRIPTION
With the input

```
dat %> rename(dScore = {dPointsEarned / dPointsPossible})
```

I got

```
Error: Arguments to rename must be unquoted variable names. Arguments dScore are not.
```

which confused me. 




I still don't think my rewrite is prefect because it's unclear whether "argument" refers to the LHS or RHS of the `=`. (i.e., do we mean ` {dPointsEarned / dPointsPossible}` was wrong? Or that `dScore` was wrong? `dScore` is the argument to `rename`, but ` {dPointsEarned / dPointsPossible}` is the "argument to that argument". And if I'm confused and not taking a long time to think it over, it won't be immediately obvious which is which.






It might also be good to somehow note that `rename` is a function name (¿at least on colour terminals?). "Arguments to rename" sounds different to "The arguments passed to the function `rename`".