### PR TITLE
Feature bind rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,9 @@
 * `lead` and `lag` correctly handle default values for string columns in
   hybrid (#1403).
 
-* `bind_rows` handles `POSIXct` stored as integer (#1402).   
+* `bind_rows` handles `POSIXct` stored as integer (#1402).
+
+* Better message when trying to use `bind_rows` on several lists (#1389).
 
 # dplyr 0.4.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 * Better message when trying to use `bind_rows` on several lists (#1389).
 
+* `bind_cols` skips `NULL` (#1148).
+
 # dplyr 0.4.3
 
 ## Improved encoding support

--- a/R/rbind.r
+++ b/R/rbind.r
@@ -70,9 +70,10 @@ NULL
 #' @rdname bind
 bind_rows <- function(..., .id = NULL) {
   dots <- list(...)
-  if (is.list(dots[[1]]) &&
-        !is.data.frame(dots[[1]]) &&
-        !length(dots[-1])) {
+  if (is.list(dots[[1]]) && !is.data.frame(dots[[1]]) ) &&
+    if( length(dots[-1]) ) {
+      stop( "undexpected input for bind_rows. expecting either a collection of data frames or a single list of data frames" )
+    }
     x <- dots[[1]]
   }
   else {

--- a/R/rbind.r
+++ b/R/rbind.r
@@ -65,15 +65,17 @@
 #' @name bind
 NULL
 
+is_dataframe_able <- function(x){
+  inherits( x, "data.frame") ||
+    is.null(x) ||
+    ( is.list(x) && !is.null(names(x)) && do.call( all.equal, unname(lapply(x, length)) ) )
+}
 
 #' @export
 #' @rdname bind
 bind_rows <- function(..., .id = NULL) {
   dots <- list(...)
-  if (is.list(dots[[1]]) && !is.data.frame(dots[[1]]) ) &&
-    if( length(dots[-1]) ) {
-      stop( "undexpected input for bind_rows. expecting either a collection of data frames or a single list of data frames" )
-    }
+  if (is.list(dots[[1]]) && !is_dataframe_able(dots[[1]]) && !length(dots[-1])) {
     x <- dots[[1]]
   }
   else {

--- a/R/rbind.r
+++ b/R/rbind.r
@@ -110,7 +110,7 @@ bind_cols <- function(...) {
   } else if( all(sapply(dots, is_dataframe_able)) ){
     x <- dots
   } else {
-    stop( "unexpected input for `bind_rows`" )
+    stop( "unexpected input for `bind_cols`" )
   }
 
   cbind_all(x)

--- a/R/rbind.r
+++ b/R/rbind.r
@@ -101,12 +101,19 @@ bind_rows <- function(..., .id = NULL) {
 
 #' @export
 #' @rdname bind
-bind_cols <- function(x, ...) {
-  if (is.list(x) && !is.data.frame(x) && !length(list(...)) ) {
-    cbind_all(x)
+bind_cols <- function(...) {
+  dots <- list(...)
+  if( all(sapply(dots, is.data.frame)) ){
+    x <- dots
+  } else if ( is.list(dots[[1]]) && length(dots) == 1L && !is_dataframe_able(dots[[1]]) ) {
+    x <- dots[[1]]
+  } else if( all(sapply(dots, is_dataframe_able)) ){
+    x <- dots
   } else {
-    cbind_all(list(x, ...))
+    stop( "unexpected input for `bind_rows`" )
   }
+
+  cbind_all(x)
 }
 
 #' @export

--- a/R/rbind.r
+++ b/R/rbind.r
@@ -66,20 +66,27 @@
 NULL
 
 is_dataframe_able <- function(x){
-  inherits( x, "data.frame") ||
-    is.null(x) ||
-    ( is.list(x) && !is.null(names(x)) && do.call( all.equal, unname(lapply(x, length)) ) )
+  if( inherits( x, "data.frame") || is.null(x) ){
+    TRUE
+  } else {
+    is.list(x) &&
+      all( sapply(x, function(.) is.vector(.) && !is.list(.)  ) ) &&
+      ( length(x) == 1 || do.call( all.equal, unname(lapply(x, length)) ) )
+  }
 }
 
 #' @export
 #' @rdname bind
 bind_rows <- function(..., .id = NULL) {
   dots <- list(...)
-  if (is.list(dots[[1]]) && !is_dataframe_able(dots[[1]]) && !length(dots[-1])) {
-    x <- dots[[1]]
-  }
-  else {
+  if( all(sapply(dots, is.data.frame)) ){
     x <- dots
+  } else if ( is.list(dots[[1]]) && length(dots) == 1L && !is_dataframe_able(dots[[1]]) ) {
+    x <- dots[[1]]
+  } else if( all(sapply(dots, is_dataframe_able)) ){
+    x <- dots
+  } else {
+    stop( "unexpected input for `bind_rows`" )
   }
 
   if (!is.null(.id)) {

--- a/inst/include/dplyr/DataFrameAble.h
+++ b/inst/include/dplyr/DataFrameAble.h
@@ -43,15 +43,6 @@ namespace dplyr {
     DataFrame data ;
   } ;
 
-  class DataFrameAble_Null : public DataFrameAbleImpl {
-  public:
-    DataFrameAble_Null(){}
-    inline int nrows() const { return 0 ;}
-    inline SEXP get(int i) const { return R_NilValue ;}
-    inline int size() const { return 0 ;}
-    inline CharacterVector names() const { return R_NilValue ; }
-  } ;
-
   class DataFrameAble_List : public DataFrameAbleImpl {
   public:
     DataFrameAble_List( SEXP data_) : data(data_), nr(0){
@@ -112,13 +103,10 @@ namespace dplyr {
       return impl->names() ;
     }
 
-  private:
     boost::shared_ptr<DataFrameAbleImpl> impl ;
 
     inline void init( SEXP data){
-      if( Rf_isNull(data) ){
-        impl.reset( new DataFrameAble_Null() ) ;
-      } else if( Rf_inherits( data, "data.frame")){
+      if( Rf_inherits( data, "data.frame")){
         impl.reset( new DataFrameAble_DataFrame(data)) ;
       } else if( is<List>(data) ){
         impl.reset( new DataFrameAble_List(data) ) ;

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -135,15 +135,17 @@ List cbind__impl( Dots dots ){
 
   std::vector<DataFrameAble> chunks ;
   for( int i=0; i<n; i++) {
+    if( ! Rf_isNull(dots[i]) )
     chunks.push_back( DataFrameAble( dots[i] ) );
   }
+  n = chunks.size() ;
 
   // first check that the number of rows is the same
   const DataFrameAble& df = chunks[0] ;
   int nrows = df.nrows() ;
   int nv = df.size() ;
   for( int i=1; i<n; i++){
-    const DataFrameAble& current = dots[i] ;
+    const DataFrameAble& current = chunks[i] ;
     if( current.nrows() != nrows ){
       stop( "incompatible number of rows (%d, expecting %d)", current.nrows(), nrows ) ;
     }
@@ -158,7 +160,7 @@ List cbind__impl( Dots dots ){
   for( int i=0, k=0 ; i<n; i++){
       Rcpp::checkUserInterrupt() ;
 
-      const DataFrameAble& current = dots[i] ;
+      const DataFrameAble& current = chunks[i] ;
       CharacterVector current_names = current.names() ;
       int nc = current.size() ;
       for( int j=0; j<nc; j++, k++){

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -5,18 +5,22 @@ using namespace dplyr ;
 
 template <typename Dots>
 List rbind__impl( Dots dots, SEXP id = R_NilValue ){
+
     int ndata = dots.size() ;
     int n = 0 ;
     std::vector<DataFrameAble> chunks ;
     std::vector<int> df_nrows ;
 
-    for( int i=0; i<ndata; i++) {
-      chunks.push_back( DataFrameAble( dots[i] ) ) ;
+    for( int i=0, k=0; i<ndata; i++) {
+      if( Rf_isNull(dots[i])) continue ;
 
-      int nrows = chunks[i].nrows() ;
+      chunks.push_back( DataFrameAble( dots[i] ) ) ;
+      int nrows = chunks[k].nrows() ;
       df_nrows.push_back(nrows) ;
       n += nrows ;
+      k++ ;
     }
+    ndata = chunks.size() ;
     pointer_vector<Collecter> columns ;
 
     std::vector<String> names ;

--- a/tests/testthat/test-cbind.R
+++ b/tests/testthat/test-cbind.R
@@ -44,3 +44,23 @@ test_that("bind_cols can handle lists (#1104)", {
   expect_is(res$y, "character")
   expect_is(res$z, "numeric")
 })
+
+test_that( "bind_cols skips NULL (#1148)", {
+  d1 <- data_frame( x = 1:10 )
+  d2 <- data_frame( y = letters[1:10] )
+
+  res <- bind_cols(NULL, d1, d2)
+  expect_equal( ncol(res), 2L )
+  expect_equal( res$x, d1$x)
+  expect_equal( res$y, d2$y)
+
+  res <- bind_cols(d1, NULL, d2)
+  expect_equal( ncol(res), 2L )
+  expect_equal( res$x, d1$x)
+  expect_equal( res$y, d2$y)
+
+  res <- bind_cols(d1, d2, NULL)
+  expect_equal( ncol(res), 2L )
+  expect_equal( res$x, d1$x)
+  expect_equal( res$y, d2$y)
+})

--- a/tests/testthat/test-rbind.r
+++ b/tests/testthat/test-rbind.r
@@ -295,5 +295,5 @@ test_that("bind_rows handles POSIXct stored as integer (#1402)", {
 test_that("bind_rows gives meaningful error msg when used on several lists (#1389)", {
   df <- lapply(1, function(x) data.frame(id=x, data=runif(5)))
   df2 <- lapply(2:3, function(x) data.frame(id=x, data=runif(5)))
-  expect_error( bind_rows(df, df2), "unexpected input for bind_rows" )
+  expect_error( bind_rows(df, df2), "unexpected input" )
 })

--- a/tests/testthat/test-rbind.r
+++ b/tests/testthat/test-rbind.r
@@ -291,3 +291,9 @@ test_that("bind_rows handles POSIXct stored as integer (#1402)", {
   expect_equal( class(res$time), c("POSIXct", "POSIXt") )
   expect_true( all(res$time == c(df1$time, df2$time) ) )
 })
+
+test_that("bind_rows gives meaningful error msg when used on several lists (#1389)", {
+  df <- lapply(1, function(x) data.frame(id=x, data=runif(5)))
+  df2 <- lapply(2:3, function(x) data.frame(id=x, data=runif(5)))
+  expect_error( bind_rows(df, df2), "unexpected input for bind_rows" )
+})

--- a/tests/testthat/test-rbind.r
+++ b/tests/testthat/test-rbind.r
@@ -220,6 +220,11 @@ test_that("bind_rows can handle lists (#1104)", {
   expect_equal(nrow(res), 2L)
   expect_is(res$x, "numeric")
   expect_is(res$y, "character")
+
+  res <- bind_rows(list(x=2, y="a"))
+  expect_equal(nrow(res), 1L)
+  expect_is(res$x, "numeric")
+  expect_is(res$y, "character")
 })
 
 test_that("rbind_list keeps ordered factors (#948)", {


### PR DESCRIPTION
I changed a bit of the logic to `bind_rows` to accommodate for both #1104 and #1389. 
@hadley can you have a look. Perhaps there is a simple way. 

The special treatment of the single list option makes it difficult. The tests we have all pass, but perhaps there's some configurations I did not take into account. 