### PR TITLE
Support complex values in matrixToDataFrame

### DIFF
--- a/src/matrixToDataFrame.cpp
+++ b/src/matrixToDataFrame.cpp
@@ -29,6 +29,9 @@ List matrixToDataFrame(RObject x) {
       case REALSXP:
         REAL(col)[i] = REAL(x)[offset + i];
         break;
+      case CPLXSXP:
+        COMPLEX(col)[i] = COMPLEX(x)[offset + i];
+        break;
       case STRSXP:
         SET_STRING_ELT(col, i, STRING_ELT(x, offset + i));
         break;


### PR DESCRIPTION
Probably we also want a meaningful error message if the type is not supported (`default` branch).

Related: hadley/tidyr#134.