### PR TITLE
Use bind_rows instead of rbind_all in do()

### DIFF
--- a/R/do.r
+++ b/R/do.r
@@ -105,7 +105,7 @@ label_output_dataframe <- function(labels, out, groups) {
   }
 
   rows <- vapply(out[[1]], nrow, numeric(1))
-  out <- rbind_all(out[[1]])
+  out <- bind_rows(out[[1]])
 
   if (!is.null(labels)) {
     # Remove any common columns from labels

--- a/tests/testthat/test-do.R
+++ b/tests/testthat/test-do.R
@@ -219,7 +219,7 @@ test_that("handling of empty data frames in do",{
   expect_equal(names(res), c("b", "blank"))
 })
 
-test_that("rbind_all checks for corrupt data frame. #1074", {
+test_that("bind_rows checks for corrupt data frame. #1074", {
   df <- data.frame(groups=c(1, 2, 3, 4,4,4), value=1) %>% group_by(groups)
   expect_error( do(df, { .[.$value==first(.$value)] }) , "corrupt"  )
 })

--- a/tests/testthat/test-rbind.r
+++ b/tests/testthat/test-rbind.r
@@ -11,19 +11,19 @@ df_var <- data.frame(
   stringsAsFactors = FALSE
 )
 
-test_that("rbind_list works on key types", {
+test_that("bind_rows works on key types", {
   exp <- tbl_df( rbind( df_var, df_var, df_var ) )
   expect_equal(
-    rbind_list( df_var, df_var, df_var) ,
+    bind_rows( df_var, df_var, df_var) ,
     exp
   )
 })
 
-test_that("rbind_list reorders columns", {
+test_that("bind_rows reorders columns", {
   columns <- seq_len(ncol(df_var))
   exp <- tbl_df( rbind( df_var, df_var, df_var ) )
   expect_equal(
-    rbind_list(
+    bind_rows(
       df_var,
       df_var[, sample(columns)],
       df_var[, sample(columns)]
@@ -32,60 +32,59 @@ test_that("rbind_list reorders columns", {
   )
 })
 
-test_that("rbind_list promotes integer to numeric", {
+test_that("bind_rows promotes integer to numeric", {
   df  <- data.frame( a = 1:5, b = 1:5 )
   df2 <- df
   df2$a <- as.numeric(df$a)
 
-  res <- rbind_list( df, df2)
+  res <- bind_rows( df, df2)
   expect_equal( typeof(res$a), "double" )
   expect_equal( typeof(res$b), "integer" )
 })
 
-test_that("rbind_list promotes factor to character", {
+test_that("bind_rows promotes factor to character", {
   df  <- data.frame( a = letters[1:5], b = 1:5, stringsAsFactors=TRUE )
   df2 <- df
   df2$a <- as.character(df$a)
-
-  res <- rbind_list( df, df2)
+  expect_warning( res <- bind_rows( df, df2), "binding factor and character vector, coercing into character vector" )
   expect_equal( typeof(res$a), "character" )
 })
 
-test_that("rbind_list doesn't promote factor to numeric", {
+test_that("bind_rows doesn't promote factor to numeric", {
   df1 <- data.frame( a = 1:5, b = 1:5 )
   df2 <- data.frame( a = 1:5, b = factor(letters[1:5]) )
 
-  expect_error(rbind_list( df1, df2 ), "incompatible type")
+  expect_error(bind_rows( df1, df2 ), "incompatible type")
 })
 
-test_that("rbind_list doesn't coerce integer to factor", {
+test_that("bind_rows doesn't coerce integer to factor", {
   df1 <- data.frame( a = 1:10, b = 1:10 )
   df2 <- data.frame( a = 1:5, b = factor(letters[1:5]) )
 
-  expect_error( rbind_list( df1, df2 ), "incompatible type" )
+  expect_error( bind_rows( df1, df2 ), "incompatible type" )
 })
 
-test_that( "rbind_list coerces factor to character when levels don't match", {
+test_that( "bind_rows coerces factor to character when levels don't match", {
   df1 <- data.frame( a = 1:3, b = factor(c("a", "b", "c")))
   df2 <- data.frame( a = 1:3, b = factor(c("a", "b", "c"),
       levels = c("b", "c", "a", "d")))
 
-  expect_warning(res <- rbind_list( df1, df2 ),
+  expect_warning(res <- bind_rows( df1, df2 ),
     "Unequal factor levels: coercing to character")
   expect_equal( res$b, c("a","b","c", "a","b","c" ) )
 })
 
-test_that( "rbind handles NULL",{
+test_that( "bind_rows handles NULL",{
   x <- cbind(a=1:10,b=1:10)
   y <- data.frame(x)
-  res <- rbind_all(list(y,y,NULL,y))
+  res <- bind_rows(list(y,y,NULL,y))
   expect_equal(nrow(res), 30L)
 })
 
-test_that( "rbind handles NA in factors #279", {
+test_that( "bind_rows handles NA in factors #279", {
   xx <- as.data.frame(list(a=as.numeric(NA), b="c", c="d"))
   zz <- as.data.frame(list(a=1, b=as.character(NA), c="b"))
-  expect_warning( res <- rbind_list( xx, zz ) )
+  expect_warning( res <- bind_rows( xx, zz ) )
 
   expect_equal(res$a, c(NA,1.0))
   expect_equal(res$b, c("c", NA))
@@ -93,12 +92,12 @@ test_that( "rbind handles NA in factors #279", {
 
 })
 
-test_that( "rbind_all only accepts data frames #288",{
+test_that( "bind_rows only accepts data frames #288",{
   ll <- list(c(1,2,3,4, 5), c(6, 7, 8, 9, 10))
-  expect_error(rbind_all(ll))
+  expect_error(bind_rows(ll))
 })
 
-test_that( "rbind propagates timezone for POSIXct #298", {
+test_that( "bind_rows propagates timezone for POSIXct #298", {
   dates1 <- data.frame(ID=c("a", "b", "c"),
                      dates=structure(c(-247320000, -246196800, -245073600),
                                      tzone = "GMT",
@@ -111,28 +110,28 @@ test_that( "rbind propagates timezone for POSIXct #298", {
                                        class = c("POSIXct", "POSIXt")),
                        stringsAsFactors=FALSE)
 
-  alldates <- rbind_list(dates1, dates2)
+  alldates <- bind_rows(dates1, dates2)
   expect_equal( attr( alldates$dates, "tzone" ), "GMT" )
 })
 
 test_that( "Collecter_Impl<REALSXP> can collect INTSXP. #321", {
-  res <- rbind_list(data.frame(x=0.5), data.frame(x=1:3))
+  res <- bind_rows(data.frame(x=0.5), data.frame(x=1:3))
   expect_equal( res$x, c(0.5, 1:3) )
 })
 
 test_that( "Collecter_Impl<INTSXP> can collect LGLSXP. #321", {
-  res <-  rbind_list(data.frame(x=1:3), data.frame(x=NA))
+  res <-  bind_rows(data.frame(x=1:3), data.frame(x=NA))
   expect_equal( res$x, c(1:3, NA) )
 })
 
-test_that("rbind_all handles list columns (#463)", {
+test_that("bind_rows handles list columns (#463)", {
   dfl <- data.frame(x = I(list(1:2, 1:3, 1:4)))
-  res <- rbind_all(list(dfl, dfl))
+  res <- bind_rows(list(dfl, dfl))
   expect_equal(rep(dfl$x,2L), res$x)
 })
 
-test_that("rbind_all creates tbl_df object", {
-  res <- rbind_list(tbl_df(mtcars))
+test_that("bind_rows creates tbl_df object", {
+  res <- bind_rows(tbl_df(mtcars))
   expect_is( res, "tbl_df" )
 })
 
@@ -141,23 +140,23 @@ test_that("string vectors are filled with NA not blanks before collection (#595)
   two <- mtcars[11:32, ]
   two$char_col <- letters[1:22]
 
-  res <- rbind_list(one, two)
+  res <- bind_rows(one, two)
   expect_true( all(is.na(res$char_col[1:10])) )
 })
 
-test_that("rbind handles data frames with no rows (#597)",{
+test_that("bind_rows handles data frames with no rows (#597)",{
   empty <- data.frame(result = numeric())
-  expect_equal(rbind_list(empty), tbl_df(empty))
-  expect_equal(rbind_list(empty, empty), tbl_df(empty))
-  expect_equal(rbind_list(empty, empty, empty), tbl_df(empty))
+  expect_equal(bind_rows(empty), tbl_df(empty))
+  expect_equal(bind_rows(empty, empty), tbl_df(empty))
+  expect_equal(bind_rows(empty, empty, empty), tbl_df(empty))
 })
 
-test_that("rbind handles all NA columns (#493)", {
+test_that("bind_rows handles all NA columns (#493)", {
   mydata <- list(
     data.frame(x=c("foo", "bar")),
     data.frame(x=NA)
   )
-  res <- rbind_all(mydata)
+  res <- bind_rows(mydata)
   expect_true( is.na(res$x[3]) )
   expect_is( res$x, "factor" )
 
@@ -165,7 +164,7 @@ test_that("rbind handles all NA columns (#493)", {
     data.frame(x=NA),
     data.frame(x=c("foo", "bar"))
   )
-  res <- rbind_all(mydata)
+  res <- bind_rows(mydata)
   expect_true( is.na(res$x[1]) )
   expect_is( res$x, "factor" )
 
@@ -222,8 +221,8 @@ test_that("bind_rows can handle lists (#1104)", {
   expect_is(res$y, "character")
 })
 
-test_that("rbind_list keeps ordered factors (#948)", {
-  y <- rbind_list(
+test_that("bind_rows keeps ordered factors (#948)", {
+  y <- bind_rows(
     data.frame(x=factor(c(1,2,3),ordered=TRUE)),
     data.frame(x=factor(c(1,2,3),ordered=TRUE))
   )


### PR DESCRIPTION
Otherwise, every use of `do()` generates the deprecation warning. I assume it should change in the tests as well?

``` r
library(dplyr)
library(broom)
iris %>% 
  group_by(Species) %>% 
  do(tidy(lm(Sepal.Width ~ Sepal.Length, .)))
#> Warning: `rbind_all()` is deprecated. Please use `bind_rows()` instead.
#> Source: local data frame [6 x 6]
#> Groups: Species [3]
#> 
#>      Species         term   estimate  std.error statistic      p.value
#>       (fctr)        (chr)      (dbl)      (dbl)     (dbl)        (dbl)
#> 1     setosa  (Intercept) -0.5694327 0.52171193 -1.091470 2.805148e-01
#> 2     setosa Sepal.Length  0.7985283 0.10396505  7.680738 6.709843e-10
#> 3 versicolor  (Intercept)  0.8721460 0.44465989  1.961378 5.564956e-02
#> 4 versicolor Sepal.Length  0.3197193 0.07463300  4.283887 8.771860e-05
#> 5  virginica  (Intercept)  1.4463054 0.43085322  3.356840 1.549367e-03
#> 6  virginica Sepal.Length  0.2318905 0.06510318  3.561892 8.434625e-04
```