### PR TITLE
make operator<<() definition for Rcomplex conditional on Rcpp <= 0.12.2

### DIFF
--- a/inst/include/tools/complex.h
+++ b/inst/include/tools/complex.h
@@ -1,8 +1,10 @@
 #ifndef dplyr_tools_complex_H
 #define dplyr_tools_complex_H
 
+#if RCPP_VERSION < Rcpp_Version(0,12,2)
 inline std::ostream & operator<<(std::ostream &os, const Rcomplex& cplx ){
     return os << cplx.r << "+" << cplx.i << "i" ;
 }
+#endif
 
 #endif


### PR DESCRIPTION
passes R CMD check with both Rcpp 0.12.1 and 0.12.2