### PR TITLE
Don't execute query for determining variable names if they are known

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/NEWS.md merge=union

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.4.3.9000
 
+* Avoid unnecessary execution of SQL query for determining column names (#1548, @krlmlr).
+
 * `bind_rows` handles 0 length named list (#1515). 
 
 * `group_by` supports `column` (#1012).

--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -13,6 +13,8 @@
 #'   dplyr. However, you should usually be able to leave this blank and it
 #'   will be determined from the context.
 tbl_sql <- function(subclass, src, from, ..., vars = attr(from, "vars")) {
+  force(vars) # to make sure default value is used
+
   if (!is.sql(from)) { # Must be a character string
     assert_that(length(from) == 1)
     if (isFALSE(db_has_table(src$con, from))) {


### PR DESCRIPTION
Solved by forcing the `vars` argument in `tbl_sql()`. The default for this argument is an attribute of the `from` argument, but that argument gets overwritten before this attribute is extracted.

Currently, `update.tbl_sql()` always needs to run `db_query_fields()` e.g. for a `left_join()`.

Closes #1549.