### PR TITLE
Let `glimpse` invisibly return original `x`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.4.3.9000
 
+*  `glimpse` now (invisibly) returns its argument (#1570).
+
 * `bind_rows` handles 0 length named list (#1515). 
 
 * `group_by` supports `column` (#1012).

--- a/R/glimpse.R
+++ b/R/glimpse.R
@@ -13,6 +13,8 @@
 #' @param x An object to glimpse at.
 #' @param width Width of output: defaults to the width of the console.
 #' @param ... Other arguments passed onto individual methods.
+#' @return x original x is (invisibly) returned, allowing \code{glimpse} to be
+#' used within a data pipe line.
 #' @export
 #' @examples
 #' glimpse(mtcars)
@@ -49,6 +51,7 @@ glimpse.tbl <- function(x, width = getOption("width"), ...) {
   truncated <- str_trunc(formatted, data_width)
 
   cat(paste0(var_names, truncated, collapse = "\n"), "\n", sep = "")
+  invisible(x)
 }
 
 #' @export
@@ -57,6 +60,7 @@ glimpse.data.frame <- glimpse.tbl
 #' @export
 glimpse.default <- function(x, width = getOption("width"), max.level = 3, ...) {
   str(x, width = width, max.level = max.level, ...)
+  invisible(x)
 }
 
 str_trunc <- function(x, max_width) {


### PR DESCRIPTION
`glimpse` currently breaks a chain of dplyr verbs:
e.g.
```R
my_iris <- 
   iris %>%
   glimpse %>%
   rename(species = Species)
```
gives an error.

This pull request lets `glimpse` return its inputs and  makes it possible to "debug"  your data processing chain by including it at various locations.
