### PR TITLE
Remove unnecessary `for` loop by adding addition operator.

### DIFF
--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -25,12 +25,12 @@ namespace dplyr {
 
         SEXP collect(){
             int ngroups = gdf.ngroups() ;
+
             if( first_non_na == ngroups ) return data ;
-            typename Data::group_iterator git = gdf.group_begin() ;
-            int i = 0 ;
-            for(; i<first_non_na; i++) ++git ;
-            ++git; i++ ;
-            for(; i<ngroups; i++, ++git){
+
+            typename Data::group_iterator git = gdf.group_begin() + first_non_na ;
+
+            for(int i = first_non_na; i < ngroups; ++i, ++git){
                 SlicingIndex indices = *git ;
                 Shield<SEXP> subset( proxy.get( indices ) ) ;
                 grab(subset, indices);
@@ -182,10 +182,8 @@ namespace dplyr {
 
         inline SEXP collect(){
           int ngroups = gdf.ngroups() ;
-          typename Data::group_iterator git = gdf.group_begin() ;
-          int i = 0 ;
-          for(; i<first_non_na; i++) ++git ;
-          for(; i<ngroups; i++, ++git){
+          typename Data::group_iterator git = gdf.group_begin() + first_non_na;
+          for(int i = first_non_na; i<ngroups; i++, ++git){
               SlicingIndex indices = *git ;
               Factor subset( proxy.get( indices ) ) ;
               grab(subset, indices);

--- a/inst/include/dplyr/GroupedDataFrame.h
+++ b/inst/include/dplyr/GroupedDataFrame.h
@@ -34,6 +34,8 @@ namespace Rcpp {
 
         GroupedDataFrameIndexIterator& operator++() ;
 
+        GroupedDataFrameIndexIterator& operator+(int) ;
+
         SlicingIndex operator*() const  ;
 
         int i ;
@@ -138,6 +140,11 @@ namespace Rcpp {
 
     inline GroupedDataFrameIndexIterator& GroupedDataFrameIndexIterator::operator++(){
         i++;
+        return *this ;
+    }
+
+    inline GroupedDataFrameIndexIterator& GroupedDataFrameIndexIterator::operator+(int n){
+        i+=n;
         return *this ;
     }
 

--- a/inst/include/dplyr/RowwiseDataFrame.h
+++ b/inst/include/dplyr/RowwiseDataFrame.h
@@ -13,6 +13,11 @@ namespace Rcpp {
             ++i ;
             return *this ;
         }
+
+        RowwiseDataFrameIndexIterator& operator+(int n) {
+            i+=n ;
+            return *this ;
+        }
         
         SlicingIndex operator*() const {
             return SlicingIndex( IntegerVector::create(i), i) ;    


### PR DESCRIPTION
While the following method does work

```c++
    for(; i<first_non_na; i++) ++git ;
```

This is a lot less efficient than what will amount to

```c++
    i+=n;
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hadley/dplyr/1609)
<!-- Reviewable:end -->
