### PR TITLE
Make current behavior of create argument in src_sqlite explicit

### DIFF
--- a/R/src-sqlite.r
+++ b/R/src-sqlite.r
@@ -9,7 +9,9 @@
 #' @template db-info
 #' @param path Path to SQLite database
 #' @param create if \code{FALSE}, \code{path} must already exist. If
-#'   \code{TRUE}, will create a new SQlite3 database at \code{path}.
+#'   \code{TRUE}, will create a new SQlite3 database at \code{path} if
+#'   \code{path} does not exist and connect to the existing database if
+#'   \code{path} does exist.
 #' @param src a sqlite src created with \code{src_sqlite}.
 #' @param from Either a string giving the name of table in database, or
 #'   \code{\link{sql}} described a derived table or compound join.


### PR DESCRIPTION
The current behavior of src_sqlite when create = TRUE is to connect to
the existing database if it is present and to create a new database if
there is no file at the specified path. The docs are not explicit about
using the existing database if it is present, which has caused some
confusion in at least one instance [1].

This change makes the current behavior explicit in the documentation.

[1] https://github.com/weecology/bbs-forecasting/pull/16#discussion_r52901968