### PR TITLE
More verbose error messages in case_when()

### DIFF
--- a/R/case_when.R
+++ b/R/case_when.R
@@ -32,7 +32,7 @@
 #'   x %% 35 == 0 ~ "fizz buzz"
 #' )
 case_when <- function(...) {
-  formula_args <- lapply(as.list(substitute(list(...))[-1]), deparse)
+  formula_args <- lapply(as.list(substitute(list(...))[-1]), deparse_trunc)
   formulas <- list(...)
   n <- length(formulas)
 
@@ -54,7 +54,7 @@ case_when <- function(...) {
 
     query[[i]] <- eval_with_expr(f[[2]], envir = env)
     if (!is.logical(query[[i]])) {
-      stop("LHS of case ", i, " (", expr(query[[i]]),
+      stop("LHS of case ", i, " (", deparse_trunc(expr(query[[i]])),
            ") is ", typeof(query[[i]]), ", not logical",
         call. = FALSE)
     }
@@ -69,11 +69,11 @@ case_when <- function(...) {
   for (i in seq_len(n)) {
     check_length(
       query[[i]], out,
-      paste0("LHS of case ", i, " (", deparse(expr(query[[i]])), ")"))
+      paste0("LHS of case ", i, " (", deparse_trunc(expr(query[[i]])), ")"))
 
     out <- replace_with(
       out, query[[i]] & !replaced, value[[i]],
-      paste0("RHS of case ", i, " (", deparse(expr(value[[i]])), ")"))
+      paste0("RHS of case ", i, " (", deparse_trunc(expr(value[[i]])), ")"))
     replaced <- replaced | query[[i]]
   }
 

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -32,7 +32,6 @@
 #'   x %% 35 == 0 ~ "fizz buzz"
 #' )
 case_when <- function(...) {
-  formula_args <- lapply(as.list(substitute(list(...))[-1]), deparse_trunc)
   formulas <- list(...)
   n <- length(formulas)
 
@@ -46,7 +45,8 @@ case_when <- function(...) {
   for (i in seq_len(n)) {
     f <- formulas[[i]]
     if (!inherits(f, "formula") || length(f) != 3) {
-      stop("Case ", i , " (", formula_args[[i]],
+      non_formula_arg <- substitute(list(...))[[i + 1]]
+      stop("Case ", i , " (", deparse_trunc(non_formula_arg),
            ") is not a two-sided formula", call. = FALSE)
     }
 

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -52,14 +52,14 @@ case_when <- function(...) {
 
     env <- environment(f)
 
-    query[[i]] <- eval_with_expr(f[[2]], envir = env)
+    query[[i]] <- eval(f[[2]], envir = env)
     if (!is.logical(query[[i]])) {
-      stop("LHS of case ", i, " (", deparse_trunc(expr(query[[i]])),
+      stop("LHS of case ", i, " (", deparse_trunc(f_lhs(f)),
            ") is ", typeof(query[[i]]), ", not logical",
         call. = FALSE)
     }
 
-    value[[i]] <- eval_with_expr(f[[3]], envir = env)
+    value[[i]] <- eval(f[[3]], envir = env)
   }
 
   m <- max(vapply(query, length, integer(1)))
@@ -69,11 +69,11 @@ case_when <- function(...) {
   for (i in seq_len(n)) {
     check_length(
       query[[i]], out,
-      paste0("LHS of case ", i, " (", deparse_trunc(expr(query[[i]])), ")"))
+      paste0("LHS of case ", i, " (", deparse_trunc(f_lhs(formulas[[i]])), ")"))
 
     out <- replace_with(
       out, query[[i]] & !replaced, value[[i]],
-      paste0("RHS of case ", i, " (", deparse_trunc(expr(value[[i]])), ")"))
+      paste0("RHS of case ", i, " (", deparse_trunc(f_rhs(formulas[[i]])), ")"))
     replaced <- replaced | query[[i]]
   }
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -133,6 +133,10 @@ unique_name <- local({
 
 isFALSE <- function(x) identical(x, FALSE)
 
+f_lhs <- function(x) if (length(x) >= 3) x[[2]] else NULL
+f_rhs <- function(x) x[[length(x)]]
+
+
 substitute_q <- function(x, env) {
   call <- substitute(substitute(x, env), list(x = x))
   eval(call)

--- a/R/utils.r
+++ b/R/utils.r
@@ -91,6 +91,17 @@ has_names <- function(x) {
   }
 }
 
+eval_with_expr <- function(expr, envir) {
+  structure(
+    eval(expr, envir),
+    expr = expr
+  )
+}
+
+expr <- function(x) {
+  attr(x, "expr")
+}
+
 "%||%" <- function(x, y) if(is.null(x)) y else x
 
 is.wholenumber <- function(x, tol = .Machine$double.eps ^ 0.5) {

--- a/R/utils.r
+++ b/R/utils.r
@@ -91,17 +91,6 @@ has_names <- function(x) {
   }
 }
 
-eval_with_expr <- function(expr, envir) {
-  structure(
-    eval(expr, envir),
-    expr = expr
-  )
-}
-
-expr <- function(x) {
-  attr(x, "expr")
-}
-
 "%||%" <- function(x, y) if(is.null(x)) y else x
 
 is.wholenumber <- function(x, tol = .Machine$double.eps ^ 0.5) {

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -5,13 +5,12 @@ test_that("zero inputs throws an error", {
 })
 
 test_that("error messages", {
-  withr::with_options(list(width = 40),
-    expect_error(
-      case_when(
-        paste("This is a", "longish", "text to test the cutoff width")
-      ),
-      "Case 1 [(]paste[(]\"This is a.*[.][.][.][)] is not a two-sided formula"
-    )
+  expect_error(
+    case_when(
+      paste(50)
+    ),
+    "Case 1 (paste(50)) is not a two-sided formula",
+    fixed = TRUE
   )
 
   expect_error(

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -4,13 +4,32 @@ test_that("zero inputs throws an error", {
   expect_error(case_when(), "No cases provided")
 })
 
+test_that("error messages", {
+  expect_error(
+    case_when(
+      identity
+    ),
+    "Case 1 (identity) is not a two-sided formula",
+    fixed = TRUE
+  )
+
+  expect_error(
+    case_when(
+      50 ~ 1:3
+    ),
+    "LHS of case 1 (50) is double, not logical",
+    fixed = TRUE
+  )
+})
+
 test_that("cases must yield compatible lengths", {
   expect_error(
     case_when(
       c(TRUE, FALSE) ~ 1,
       c(FALSE, TRUE, FALSE) ~ 2
     ),
-    "LHS of case 1 is length 2"
+    "LHS of case 1 (c(TRUE, FALSE)) is length 2",
+    fixed = TRUE
   )
 
   expect_error(
@@ -18,7 +37,8 @@ test_that("cases must yield compatible lengths", {
       c(TRUE, FALSE) ~ 1:3,
       c(FALSE, TRUE) ~ 1:2
     ),
-    "RHS of case 1 is length 3"
+    "RHS of case 1 (1:3) is length 3",
+    fixed = TRUE
   )
 })
 

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -5,12 +5,13 @@ test_that("zero inputs throws an error", {
 })
 
 test_that("error messages", {
-  expect_error(
-    case_when(
-      identity
-    ),
-    "Case 1 (identity) is not a two-sided formula",
-    fixed = TRUE
+  withr::with_options(list(width = 40),
+    expect_error(
+      case_when(
+        paste("This is a", "longish", "text to test the cutoff width")
+      ),
+      "Case 1 [(]paste[(]\"This is a.*[.][.][.][)] is not a two-sided formula"
+    )
   )
 
   expect_error(


### PR DESCRIPTION
by showing the expression that fails.  Useful for `transmute()` fests where many variables are recoded.

~~Implementation: New eval_with_expr() and expr() that store the original expression along with the result.~~

Also fixes glitch in the first LHS error message ([ vs. [[).

With test.

Related to #631.