### PR TITLE
update the progress bar only 20 times per second

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.4.3.9000
 
+* The progress bar in `do()` is now updated at most 20 times per second, avoiding uneccessary redraws (#1734, @mkuhn)
+
 * joins allows extra attributes if they are identical (#1636)
 
 * `summarise()` correctly coerces factors with different levels (#1678)

--- a/R/progress.R
+++ b/R/progress.R
@@ -47,6 +47,7 @@ Progress <- R6::R6Class("Progress",
     stopped = FALSE,
     stop_time = NULL,
     min_time = NULL,
+    last_update = NULL,
 
     initialize = function(n, min_time = 0, ...) {
       self$n <- n
@@ -57,7 +58,7 @@ Progress <- R6::R6Class("Progress",
     begin = function() {
       "Initialise timer. Call this before beginning timing."
       self$i <- 0
-      self$init_time <- now()
+      self$last_update <- self$init_time <- now()
       self$stopped <- FALSE
       self
     },
@@ -95,9 +96,12 @@ Progress <- R6::R6Class("Progress",
          !is.null(getOption("knitr.in.progress"))) { # dplyr used within knitr document
         return(invisible(self))
       }
-      if (now() - self$init_time < self$min_time) {
+
+      now_ <- now()
+      if (now_ - self$init_time < self$min_time || now_ - self$last_update < 0.05) {
         return(invisible(self))
       }
+      self$last_update <- now_
 
       if (self$stopped) {
         overall <- show_time(self$stop_time - self$init_time)


### PR DESCRIPTION
I noticed that RStudio has a high CPU load while running `do` on data frames with many groups and short operations. I traced this to the fact that the progress bar is re-drawn for each tick, even if it hasn't changed since the last update. 

I therefore added a check for when the progress bar has been drawn the last time, and update only if this is more than 50 ms ago. A simple test revealed that this can save a lot of overhead without noticeable changes (first run: normal dplyr, second run: with `last_update` check):

```
> d <- data.frame(x=1:100000)
> system.time(invisible(d %>% group_by(x) %>% do(x=0)))
|==========================================================================================|100% ~0 s remaining        
user  system elapsed
 33.535   2.976  28.715 

Restarting R session...

> library(dplyr)
> system.time(invisible(d %>% group_by(x) %>% do(x=0)))
|========================================================================================= | 99% ~0 s remaining
user  system elapsed 
  3.845   0.109   4.009 
```