### PR TITLE
check for zero-length vars in distinct

### DIFF
--- a/R/distinct.R
+++ b/R/distinct.R
@@ -57,6 +57,11 @@ distinct_vars <- function(.data, ..., .dots, .keep_all = FALSE) {
 
   if (.keep_all) {
     keep <- names(.data)
+    # This prevents an error from being thrown on the next conditional
+    # if there are no variables selected.
+    if (length(vars) == 0){
+      vars <- keep
+    }
   } else {
     keep <- vars
   }


### PR DESCRIPTION
I noticed that when distinct is run without any variables selected, it returns an error on the conditional that checks for zero-length vars. This would prevent that.
