### PR TITLE
add support for using limit on sql select

### DIFF
--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -13,13 +13,15 @@ NULL
 #' @rdname backend_sql
 #' @export
 sql_select <- function(con, select, from, where = NULL, group_by = NULL,
-                       having = NULL, order_by = NULL, distinct = FALSE, ...) {
+                       having = NULL, order_by = NULL, distinct = FALSE,
+                       limit = NULL, ...) {
   UseMethod("sql_select")
 }
 #' @export
 sql_select.default <- function(con, select, from, where = NULL,
                                group_by = NULL, having = NULL,
-                               order_by = NULL, distinct = FALSE, ...) {
+                               order_by = NULL, distinct = FALSE,
+                               limit = NULL, ...) {
 
   out <- vector("list", 6)
   names(out) <- c("select", "from", "where", "group_by", "having", "order_by")
@@ -57,6 +59,11 @@ sql_select.default <- function(con, select, from, where = NULL,
     assert_that(is.character(order_by))
     out$order_by <- build_sql("ORDER BY ",
       escape(order_by, collapse = ", ", con = con))
+  }
+
+  if (length(limit) > 0L) {
+    assert_that(is.numeric(limit))
+    out$limit <- build_sql("LIMIT ", escape(limit, con = con))
   }
 
   escape(unname(compact(out)), collapse = "\n", parens = FALSE, con = con)

--- a/R/sql-query.R
+++ b/R/sql-query.R
@@ -10,7 +10,8 @@ select_query <- function(from,
                          group_by = character(),
                          having = character(),
                          order_by = character(),
-                         distinct = FALSE) {
+                         distinct = FALSE,
+                         limit = integer()) {
 
   stopifnot(is.character(select))
   stopifnot(is.character(where))
@@ -27,7 +28,8 @@ select_query <- function(from,
       group_by = group_by,
       having = having,
       order_by = order_by,
-      distinct = distinct
+      distinct = distinct,
+      limit = limit
     ),
     class = c("select_query", "query")
   )
@@ -43,6 +45,7 @@ print.select_query <- function(x, ...) {
   if (length(x$group_by)) cat("Group by: ", named_commas(x$group_by), "\n", sep = "")
   if (length(x$order_by)) cat("Order by: ", named_commas(x$order_by), "\n", sep = "")
   if (length(x$having))   cat("Having:   ", named_commas(x$having), "\n", sep = "")
+  if (length(x$limit))    cat("Limit:    ", named_commas(x$limit), "\n", sep = "")
 }
 
 

--- a/R/sql-render.R
+++ b/R/sql-render.R
@@ -26,7 +26,7 @@ sql_render.select_query <- function(query, con = NULL, ..., root = FALSE) {
   sql_select(
     con, query$select, from, where = query$where, group_by = query$group_by,
     having = query$having, order_by = query$order_by, distinct = query$distinct,
-    ...
+    limit = query$limit, ...
   )
 }
 


### PR DESCRIPTION
@hadley I'm implementing the use of `LIMIT` while fetching rows in `collect`. This is my first attempt, planning to run `testthat` and iterate as needed tomorrow. However, I think I could use some feedback before I get further:

1. Is there any particular reason why `dplyr` currently does not use `LIMIT` in `collect` queries?
2. Any pointers on how to test `LIMIT` with queries or other paths? From the code, it seems to me I'm not generating `LIMIT` through all entries, would be good to know which paths I should track.