### PR TITLE
allow tables to be subclassed

### DIFF
--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -13,7 +13,7 @@
 #'   dplyr. However, you should usually be able to leave this blank and it
 #'   will be determined from the context.
 tbl_sql <- function(subclass, src, from, ..., vars = attr(from, "vars")) {
-  make_tbl(c("sql", "lazy"), src = src, ops = op_base_remote(src, from))
+  make_tbl(c(subclass, "sql", "lazy"), src = src, ops = op_base_remote(src, from))
 }
 
 #' @export


### PR DESCRIPTION
@hadley: Am I subclassing a `tbl_sql` incorrectly or are we missing to subclass this in dplyr?

This is what I'm doing:

```
#' @export
tbl.src_s <- function(src, from, ...) {
  tbl_sql("s", src = src, from = from, ...)
}
```

However, the generated table is not of type "s". The change in the PR solves this issue.