### PR TITLE
add COMMIT for postgres

### DIFF
--- a/R/src-postgres.r
+++ b/R/src-postgres.r
@@ -156,6 +156,11 @@ db_begin.PostgreSQLConnection <- function(con, ...) {
   dbGetQuery(con, "BEGIN TRANSACTION")
 }
 
+#' @export
+db_commit.PostgreSQLConnection <- function(con, ...) {
+  dbGetQuery(con, "COMMIT")
+}
+
 # http://www.postgresql.org/docs/9.3/static/sql-explain.html
 #' @export
 db_explain.PostgreSQLConnection <- function(con, sql, format = "text", ...) {


### PR DESCRIPTION
It seems PostgreSQL backend did not implement "COMMIT" method. I add the missing method for postgresql.
