### PR TITLE
avoid generating PARTITION BY for empty ones

### DIFF
--- a/R/over.R
+++ b/R/over.R
@@ -4,6 +4,9 @@
 # over("avg(x)", order = c("x", "y"))
 # over("avg(x)")
 over <- function(expr, partition = NULL, order = NULL, frame = NULL) {
+  if (length(partition) == 0) {
+    partition <- NULL
+  }
   if (!is.null(partition)) {
     if (!is.sql(partition)) {
       partition <- ident(partition)

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -129,7 +129,7 @@ sql_build.op_filter <- function(op, con, ...) {
     # create mutate operation
     mutate_dots <- lapply(where$comp, lazyeval::as.lazy)
     mutated <- sql_build(op_single("mutate", op$x, dots = mutate_dots), con)
-    where_sql <- translate_sql_(where$expr, vars = vars)
+    where_sql <- translate_sql_(where$expr, con = con, vars = vars)
 
     select_query(mutated, select = ident(vars), where = where_sql)
   }


### PR DESCRIPTION
@hadley: While trying to generate a dplyr partition for this expression for a new backend:

`tbl(db, "flights") %>% filter(min_rank(dep_time) < 2) %>% collect`

the generated SQL was this: 

```
<SQL> SELECT *
FROM (SELECT `year`, `month`, `day`, `dep_time`, `dep_delay`, `arr_time`, `arr_delay`, `carrier`, `tailnum`, `flight`, `origin`, `dest`, `air_time`, `distance`, `hour`, `minute`
FROM (SELECT `year`, `month`, `day`, `dep_time`, `dep_delay`, `arr_time`, `arr_delay`, `carrier`, `tailnum`, `flight`, `origin`, `dest`, `air_time`, `distance`, `hour`, `minute`, rank() OVER (PARTITION BY ORDER BY `dep_time`) AS `zzz4`
FROM `flights`) `mflbvzuway`
WHERE ("zzz4" < 2.0)) `kgbnssdkik`
LIMIT 100000
```

Notice:
1) The `PARTITION BY ORDER BY` clause, this was being caused by, `op_grps.op_base <- function(op) character()` and `order <-` since the group operator is the default and not null. I was not sure if the best fix would be to change the base operator default, but I leaned towards the safer one to scope this to `OVER` sql clauses.
2) Even with the fix for (1), the escaping `"zzz4"` was incorrect, I believe for this one we do need to pass the connection `con` to allow other backends to override the escaping functionality.

Let me know what you think, thanks!