### PR TITLE
Remove dtplyr from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Suggests:
     dtplyr
 Remotes:
     hadley/testthat,
-    hadley/dtplyr,
     hadley/tibble
 VignetteBuilder: knitr
 LinkingTo: Rcpp (>= 0.12.0),


### PR DESCRIPTION
devtools can't currently handle this in a nice way, I've tried quite a few different configurations.

Looks like dplyr -> (suggests) dtplyr -> (imports, with version) dplyr, in combination with remotes, is the problem here.

Fixes #1809.