### PR TITLE
WIP: Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools')"
-  - Rscript -e "devtools::install_deps(dependencies = TRUE)"
+  - Rscript -e "devtools::install(dependencies = TRUE)"
 
 before_script:
   - psql -c 'create database test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ r:
 
 warnings_are_errors: false
 env:
-- _R_CHECK_FORCE_SUGGESTS_=false
+  global:
+    - _R_CHECK_FORCE_SUGGESTS_=false
 
 before_install:
+  - Rscript -e "install.packages('git2r')"
+  - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
 before_install:
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools#1184')"
-  - Rscript -e "devtools::install_deps()"
-  - Rscript -e "devtools::install_github('hadley/dtplyr')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ r:
   - release
   - devel
 
+r_github_packages: hadley/devtools#1181
+
 warnings_are_errors: false
 env:
 - _R_CHECK_FORCE_SUGGESTS_=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
 language: R
 sudo: false
 cache: packages
+r:
+  - oldrel
+  - release
+  - devel
 
 warnings_are_errors: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
   - Rscript -e "install.packages('git2r')"
   - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
-  - Rscript -e "devtools::install_github('hadley/devtools')"
-  - Rscript -e "devtools::install_deps()"
+  - Rscript -e "devtools::install_github('hadley/devtools#1183')"
+  - Rscript -e "devtools::install()"
   - Rscript -e "devtools::install_github('hadley/dtplyr')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ warnings_are_errors: false
 env:
 - _R_CHECK_FORCE_SUGGESTS_=false
 
+before_install:
+  - Rscript -e "devtools::install_deps(dependencies = TRUE)"
+
 before_script:
   - psql -c 'create database test;' -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 
 before_install:
   - Rscript -e "install.packages('devtools')"
-  - Rscript -e "devtools::install_github('hadley/devtools#1181')"
+  - Rscript -e "devtools::install_github('hadley/devtools')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
   - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools')"
+  - Rscript -e "devtools::install()"
+  - Rscript -e "devtools::install_github('hadley/dtplyr')"
   - Rscript -e "devtools::install(dependencies = TRUE)"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ before_install:
   - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools')"
-  - Rscript -e "devtools::install()"
+  - Rscript -e "devtools::install_deps()"
   - Rscript -e "devtools::install_github('hadley/dtplyr')"
-  - Rscript -e "devtools::install(dependencies = TRUE)"
+  - Rscript -e "devtools::install_deps(dependencies = TRUE)"
 
 before_script:
   - psql -c 'create database test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
   - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools#1183')"
-  - Rscript -e "devtools::install_deps()"
   - Rscript -e "devtools::install()"
   - Rscript -e "devtools::install_github('hadley/dtplyr')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - _R_CHECK_FORCE_SUGGESTS_=false
 
 before_install:
-  - Rscript -e "install.packages('git2r')"
+  - Rscript -e "install.packages('git2r')" # remove this once git2r > 0.14.0 is on CRAN
   - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools#1183')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - Rscript -e "install.packages('git2r')" # remove this once git2r > 0.14.0 is on CRAN
   - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
-  - Rscript -e "devtools::install_github('hadley/devtools#1183')"
+  - Rscript -e "devtools::install_github('hadley/devtools')"
   - Rscript -e "devtools::install()"
   - Rscript -e "devtools::install_github('hadley/dtplyr')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_install:
   - Rscript -e "install.packages('devtools')"
-  - Rscript -e "devtools::install_github('hadley/devtools')"
+  - Rscript -e "devtools::install_github('hadley/devtools#1184')"
   - Rscript -e "devtools::install_deps()"
   - Rscript -e "devtools::install_github('hadley/dtplyr')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 before_install:
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools')"
-  - Rscript -e "devtools::install()"
+  - Rscript -e "devtools::install_deps()"
   - Rscript -e "devtools::install_github('hadley/dtplyr')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ r:
   - release
   - devel
 
-r_github_packages: hadley/devtools#1181
-
 warnings_are_errors: false
 env:
 - _R_CHECK_FORCE_SUGGESTS_=false
 
 before_install:
+  - Rscript -e "install.packages('devtools')"
+  - Rscript -e "devtools::install_github('hadley/devtools#1181')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ warnings_are_errors: false
 env:
   global:
     - _R_CHECK_FORCE_SUGGESTS_=false
+    - MAKEFLAGS="-j 2"
 
 before_install:
-  - Rscript -e "install.packages('git2r')" # remove this once git2r > 0.14.0 is on CRAN
-  - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools')"
   - Rscript -e "devtools::install()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - export MAKEFLAGS="-j 2"
   - Rscript -e "install.packages('devtools')"
   - Rscript -e "devtools::install_github('hadley/devtools#1183')"
+  - Rscript -e "devtools::install_deps()"
   - Rscript -e "devtools::install()"
   - Rscript -e "devtools::install_github('hadley/dtplyr')"
   - Rscript -e "devtools::install_deps(dependencies = TRUE)"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Suggests:
     dtplyr
 Remotes:
     hadley/testthat,
+    hadley/dtplyr,
     hadley/tibble
 VignetteBuilder: knitr
 LinkingTo: Rcpp (>= 0.12.0),


### PR DESCRIPTION
Need to manually install dev version of devtools, then the dplyr package (with essential deps), then dtplyr, then the suggests. I hope devtools can handle this one day.

Also, enables testing of r-devel and r-oldrel. The build fails on r-release because of #1806.

Currently, devtools is installed from a pull request to achieve the functionality; I'll update it once hadley/devtools#1183 is merged.

Closes #1812 (=includes it).