### PR TITLE
WIP: Avoid segfaults for unsupported types

### DIFF
--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -382,6 +382,8 @@ namespace dplyr {
         case VECSXP: return new Collecter_Impl<VECSXP>(n) ;
         default: break ;
         }
+
+        stop( "unimplemented vector type: %d", TYPEOF(model) ) ;
         return 0 ;
     }
 
@@ -415,6 +417,8 @@ namespace dplyr {
           return new Collecter_Impl<STRSXP>(n) ;
         default: break ;
         }
+
+        stop( "unimplemented vector type: %d", TYPEOF(model) ) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -383,7 +383,7 @@ namespace dplyr {
         default: break ;
         }
 
-        stop( "unimplemented vector type: %d", TYPEOF(model) ) ;
+        stop( "unimplemented vector type: %s", Rf_type2rstr(TYPEOF(model)) ) ;
         return 0 ;
     }
 
@@ -418,7 +418,7 @@ namespace dplyr {
         default: break ;
         }
 
-        stop( "unimplemented vector type: %d", TYPEOF(model) ) ;
+        stop( "unimplemented vector type: %s", Rf_type2rstr(TYPEOF(model)) ) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -276,6 +276,8 @@ namespace dplyr {
             case VECSXP:  return new ConstantGathererImpl<STRSXP>( x, n ) ;
             default: break ;
         }
+
+        stop( "unimplemented vector type: %d", TYPEOF(x) ) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -277,7 +277,7 @@ namespace dplyr {
             default: break ;
         }
 
-        stop( "unimplemented vector type: %d", TYPEOF(x) ) ;
+        stop( "unimplemented vector type: %s", Rf_type2rstr(TYPEOF(x)) ) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/Order.h
+++ b/inst/include/dplyr/Order.h
@@ -13,7 +13,6 @@ namespace dplyr {
             nrows = Rf_length( args[0] );
             for( int i=0; i<n; i++){
                 OrderVisitor* v = order_visitor( args[i], ascending[i] ) ;
-                if( !v ) stop("Cannot order based on this column") ;
                 visitors[i]  = v ;
             }
         }

--- a/inst/include/dplyr/OrderVisitorImpl.h
+++ b/inst/include/dplyr/OrderVisitorImpl.h
@@ -196,7 +196,8 @@ namespace dplyr {
                     default: break ;
                 }
             }
-            stop( "unimplemented matrix type" ) ;
+
+            stop( "unimplemented matrix type: %d", TYPEOF(vec) ) ;
             return 0 ;
         }
 
@@ -235,7 +236,7 @@ namespace dplyr {
             }
         }
 
-        // should not happen
+        stop( "unimplemented vector type: %d", TYPEOF(vec) ) ;
         return 0 ;
     }
 }

--- a/inst/include/dplyr/OrderVisitorImpl.h
+++ b/inst/include/dplyr/OrderVisitorImpl.h
@@ -197,7 +197,7 @@ namespace dplyr {
                 }
             }
 
-            stop( "unimplemented matrix type: %d", TYPEOF(vec) ) ;
+            stop( "unimplemented matrix type: %s", Rf_type2rstr(TYPEOF(vec)) ) ;
             return 0 ;
         }
 
@@ -236,7 +236,7 @@ namespace dplyr {
             }
         }
 
-        stop( "unimplemented vector type: %d", TYPEOF(vec) ) ;
+        stop( "unimplemented vector type: %s", Rf_type2rstr(TYPEOF(vec)) ) ;
         return 0 ;
     }
 }

--- a/inst/include/dplyr/Replicator.h
+++ b/inst/include/dplyr/Replicator.h
@@ -46,7 +46,7 @@ namespace dplyr {
             default: break ;
         }
 
-        stop( "unimplemented type: %d", TYPEOF(v) ) ;
+        stop( "unimplemented type: %s", Rf_type2rstr(TYPEOF(v)) ) ;
         return 0 ;
     }
     

--- a/inst/include/dplyr/Replicator.h
+++ b/inst/include/dplyr/Replicator.h
@@ -45,8 +45,8 @@ namespace dplyr {
             case CPLXSXP:  return new ReplicatorImpl<CPLXSXP, Data> ( v, n, gdf.ngroups() ) ;
             default: break ;
         }
-        stop( "cannot handle variable" ) ;
-        
+
+        stop( "unimplemented type: %d", TYPEOF(v) ) ;
         return 0 ;
     }
     

--- a/inst/include/dplyr/subset_visitor.h
+++ b/inst/include/dplyr/subset_visitor.h
@@ -13,9 +13,11 @@ namespace dplyr {
             case LGLSXP:  return new MatrixColumnSubsetVisitor<LGLSXP>( vec ) ;
             case STRSXP:  return new MatrixColumnSubsetVisitor<STRSXP>( vec ) ;
             case VECSXP:  return new MatrixColumnSubsetVisitor<VECSXP>( vec ) ;
-            default:
-                return 0 ;
+            default: break;
             }
+
+            stop( "unimplemented matrix type: %d", TYPEOF(vec) ) ;
+            return 0;
         }
 
         if( Rf_inherits(vec, "Date") ){
@@ -45,7 +47,7 @@ namespace dplyr {
             default: break ;
         }
 
-        // should not happen
+        stop( "unimplemented vector type: %d", TYPEOF(vec) ) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/subset_visitor.h
+++ b/inst/include/dplyr/subset_visitor.h
@@ -16,7 +16,7 @@ namespace dplyr {
             default: break;
             }
 
-            stop( "unimplemented matrix type: %d", TYPEOF(vec) ) ;
+            stop( "unimplemented matrix type: %s", Rf_type2rstr(TYPEOF(vec)) ) ;
             return 0;
         }
 
@@ -47,7 +47,7 @@ namespace dplyr {
             default: break ;
         }
 
-        stop( "unimplemented vector type: %d", TYPEOF(vec) ) ;
+        stop( "unimplemented vector type: %s", Rf_type2rstr(TYPEOF(vec)) ) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/visitor.h
+++ b/inst/include/dplyr/visitor.h
@@ -16,7 +16,7 @@ namespace dplyr {
             default: break ;
             }
 
-            stop( "unimplemented matrix type: %d", TYPEOF(vec) ) ;
+            stop( "unimplemented matrix type: %s", Rf_type2rstr(TYPEOF(vec)) ) ;
         }
 
         switch( TYPEOF(vec) ){
@@ -43,7 +43,7 @@ namespace dplyr {
             default: break ;
         }
 
-        stop( "unimplemented vector type: %d", TYPEOF(vec) ) ;
+        stop( "unimplemented vector type: %s", Rf_type2rstr(TYPEOF(vec)) ) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/visitor.h
+++ b/inst/include/dplyr/visitor.h
@@ -13,9 +13,10 @@ namespace dplyr {
             case LGLSXP: return new MatrixColumnVisitor<LGLSXP>( vec ) ;
             case STRSXP: return new MatrixColumnVisitor<STRSXP>( vec ) ;
             case VECSXP: return new MatrixColumnVisitor<VECSXP>( vec ) ;
-            default:
-                return 0 ;
+            default: break ;
             }
+
+            stop( "unimplemented matrix type: %d", TYPEOF(vec) ) ;
         }
 
         switch( TYPEOF(vec) ){
@@ -42,7 +43,7 @@ namespace dplyr {
             default: break ;
         }
 
-        // should not happen
+        stop( "unimplemented vector type: %d", TYPEOF(vec) ) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/white_list.h
+++ b/inst/include/dplyr/white_list.h
@@ -3,11 +3,17 @@
 
 namespace dplyr{
 
+    inline bool white_list_vector(SEXP x);
+
     inline bool white_list(SEXP x){
         if( Rf_isMatrix(x) ) {
             // might have to refine later
             return true ;
         }
+        return white_list_vector(x);
+    }
+
+    inline bool white_list_vector(SEXP x) {
         switch( TYPEOF(x) ){
             case INTSXP:   return true ;
             case REALSXP:  return true ;
@@ -18,7 +24,7 @@ namespace dplyr{
                     if( Rf_inherits( x, "POSIXlt") ) return false ;
                     return true ;
             }
-            
+
             default: break ;
         }
         return false ;

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -147,5 +147,5 @@ test_that("arrange fails gracefully on list comumns (#1489)",{
   df <- expand.grid(group = 1:2, y = 1, x = 1) %>%
     group_by(group) %>%
     do(fit = lm(data = ., y ~ x))
-  expect_error( arrange(df, fit), "Cannot order based on this column" )
+  expect_error( arrange(df, fit), "unimplemented vector type" )
 })


### PR DESCRIPTION
Fixes #1803.

The error should be raised in a central location, and textual type descriptions should be printed (with Rf_type2char). This is largely obsolete by #1817, but should be added nevertheless to avoid surprises.