### PR TITLE
all_equal() fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,15 @@
 
 * Avoiding segfaults in presence of `raw` columns (#1803, #1817, @krlmlr).
 
+* `all_equal()` shows better error message when comparing raw values
+  or when types are incompatible and `convert = TRUE` (#1820, @krlmlr).
+
 * Fixed bug about joins when factor levels not equal (#1712, #1559).
 
 * anti and semi joins give correct result when by variable is a factor
   and don't warn (#1571).
 
-* setdiff handles factors with NA (#1526).
+* `setdiff()` handles factors with `NA` (#1526).
 
 * enabling joining of data frames that don't have the same encoding of
   column names (#1513).

--- a/src/dplyr.cpp
+++ b/src/dplyr.cpp
@@ -980,12 +980,12 @@ dplyr::BoolResult compatible_data_frame( DataFrame x, DataFrame y, bool ignore_c
       }
 
       if( typeid(*px) != typeid(*py) ) {
-        if( !convert ) {
-          ss << "Incompatible type for column "
-             << name.get_cstring()
-             << ": x " << vx->get_r_type()
-             << ", y " << vy->get_r_type() ;
+        ss << "Incompatible type for column "
+           << name.get_cstring()
+           << ": x " << vx->get_r_type()
+           << ", y " << vy->get_r_type() ;
 
+        if( !convert ) {
           ok = false ;
           continue ;
         }

--- a/src/dplyr.cpp
+++ b/src/dplyr.cpp
@@ -969,16 +969,6 @@ dplyr::BoolResult compatible_data_frame( DataFrame x, DataFrame y, bool ignore_c
       SubsetVectorVisitor* px = vx.get() ;
       SubsetVectorVisitor* py = vy.get() ;
 
-      if( !px || !py ) {
-        ss << "Cannot handle type for column "
-           << name.get_cstring()
-           << ": x " << Rf_type2char(TYPEOF(xi))
-           << ", y " << Rf_type2char(TYPEOF(yi)) ;
-
-        ok = false ;
-        continue ;
-      }
-
       if( typeid(*px) != typeid(*py) ) {
         ss << "Incompatible type for column "
            << name.get_cstring()

--- a/src/dplyr.cpp
+++ b/src/dplyr.cpp
@@ -991,7 +991,7 @@ dplyr::BoolResult compatible_data_frame( DataFrame x, DataFrame y, bool ignore_c
         }
       }
 
-      if( ! vx->is_compatible( vy.get(), ss, name ) ) {
+      if( ! vx->is_compatible( py, ss, name ) ) {
         ok = false ;
       }
     }

--- a/src/dplyr.cpp
+++ b/src/dplyr.cpp
@@ -972,8 +972,8 @@ dplyr::BoolResult compatible_data_frame( DataFrame x, DataFrame y, bool ignore_c
       if( !px || !py ) {
         ss << "Cannot handle type for column "
            << name.get_cstring()
-           << ": x " << Rf_type2char(TYPEOF(x))
-           << ", y " << Rf_type2char(TYPEOF(y)) ;
+           << ": x " << Rf_type2char(TYPEOF(xi))
+           << ", y " << Rf_type2char(TYPEOF(yi)) ;
 
         ok = false ;
         continue ;

--- a/src/dplyr.cpp
+++ b/src/dplyr.cpp
@@ -969,6 +969,16 @@ dplyr::BoolResult compatible_data_frame( DataFrame x, DataFrame y, bool ignore_c
       SubsetVectorVisitor* px = vx.get() ;
       SubsetVectorVisitor* py = vy.get() ;
 
+      if( !px || !py ) {
+        ss << "Cannot handle type for column "
+           << name.get_cstring()
+           << ": x " << Rf_type2char(TYPEOF(x))
+           << ", y " << Rf_type2char(TYPEOF(y)) ;
+
+        ok = false ;
+        continue ;
+      }
+
       if( typeid(*px) != typeid(*py) ) {
         if( !convert ) {
           ss << "Incompatible type for column "

--- a/tests/testthat/test-equality.r
+++ b/tests/testthat/test-equality.r
@@ -104,3 +104,17 @@ test_that("equality fails gracefully in presence of raw columns", {
   df <- data_frame(a = 1:3, b = as.raw(1:3))
   expect_match(all.equal(df, df), "Cannot handle")
 })
+
+test_that("equality returns a message for convert = TRUE", {
+  df1 <- data_frame(x = 1:3)
+  df2 <- data_frame(x = as.character(1:3))
+  expect_match(all.equal(df1, df2), "Incompatible")
+  expect_match(all.equal(df1, df2, convert = TRUE), "Incompatible")
+})
+
+test_that("numeric and integer can be compared if convert = TRUE", {
+  df1 <- data_frame(x = 1:3)
+  df2 <- data_frame(x = as.numeric(1:3))
+  expect_match(all.equal(df1, df2), "Incompatible")
+  expect_true(all.equal(df1, df2, convert = TRUE))
+})

--- a/tests/testthat/test-equality.r
+++ b/tests/testthat/test-equality.r
@@ -102,7 +102,7 @@ test_that("equality handles data frames with 0 columns (#1506)", {
 
 test_that("equality fails gracefully in presence of raw columns", {
   df <- data_frame(a = 1:3, b = as.raw(1:3))
-  expect_match(all.equal(df, df), "Cannot handle")
+  expect_match(all.equal(df, df), "Cannot handle.*raw.*raw")
 })
 
 test_that("equality returns a message for convert = TRUE", {

--- a/tests/testthat/test-equality.r
+++ b/tests/testthat/test-equality.r
@@ -100,9 +100,9 @@ test_that("equality handles data frames with 0 columns (#1506)", {
   expect_equal(df0, df0)
 })
 
-test_that("equality fails gracefully in presence of raw columns", {
+test_that("equality cannot be checked in presence of raw columns", {
   df <- data_frame(a = 1:3, b = as.raw(1:3))
-  expect_match(all.equal(df, df), "Cannot handle.*raw.*raw")
+  expect_error(all.equal(df, df), "Unsupported vector type raw")
 })
 
 test_that("equality returns a message for convert = TRUE", {

--- a/tests/testthat/test-equality.r
+++ b/tests/testthat/test-equality.r
@@ -90,8 +90,13 @@ test_that("equality test fails when convert is FALSE and types don't match (#148
   expect_warning( all_equal(df1, df2, convert = TRUE) )
 })
 
-test_that("equality handles data frames with 0 columns (#1506)", {
+test_that("equality handles data frames with 0 rows (#1506)", {
   df0 <- data_frame(x = numeric(0), y = character(0) )
+  expect_equal(df0, df0)
+})
+
+test_that("equality handles data frames with 0 columns (#1506)", {
+  df0 <- data_frame(a = 1:10)[-1]
   expect_equal(df0, df0)
 })
 

--- a/tests/testthat/test-equality.r
+++ b/tests/testthat/test-equality.r
@@ -94,3 +94,8 @@ test_that("equality handles data frames with 0 columns (#1506)", {
   df0 <- data_frame(x = numeric(0), y = character(0) )
   expect_equal(df0, df0)
 })
+
+test_that("equality fails gracefully in presence of raw columns", {
+  df <- data_frame(a = 1:3, b = as.raw(1:3))
+  expect_match(all.equal(df, df), "Cannot handle")
+})


### PR DESCRIPTION
- legible error message for raw types which cannot be handled currently
- show message if types are incompatible and convert = TRUE
- tests