### PR TITLE
Improve default handling in recode.factor() and recode_factor()

### DIFF
--- a/R/recode.R
+++ b/R/recode.R
@@ -137,6 +137,7 @@ recode.factor <- function(.x, ..., .default = NULL, .missing = NULL) {
     replaced[levels(.x) == nm] <- TRUE
   }
 
+  .default <- recode_factor_default(.default, .x)
   out <- replace_with(out, !replaced, .default, "`.default`")
   levels(.x) <- out
 
@@ -163,24 +164,23 @@ recode_default <- function(default, x, out) {
   }
 }
 
+recode_factor_default <- function(default, x) {
+  if (is.null(default) && is.factor(x)) {
+    default <- levels(x)
+  }
+
+  default
+}
+
 #' @rdname recode
 #' @export
 recode_factor <- function (.x, ..., .default = NULL, .missing = NULL,
                            .ordered = FALSE) {
   recoded <- recode(.x, ..., .default = .default, .missing = .missing)
 
-  levels <- c(...,
-    recode_factor_default(.default),
-    recode_factor_default(.missing)
-  )
+  all_levels <- unique(c(..., recode_factor_default(.default, .x), .missing))
+  recoded_levels <- if (is.factor(recoded)) levels(recoded) else unique(recoded)
+  levels <- intersect(all_levels, recoded_levels)
 
   factor(recoded, levels, ordered = .ordered)
-}
-
-recode_factor_default <- function(default) {
-  if (length(default) == 1 && !is.na(default)) {
-    default
-  } else {
-    NULL
-  }
 }

--- a/R/recode.R
+++ b/R/recode.R
@@ -39,7 +39,7 @@
 #' recode(x, `2` = 20L, `4` = 40L)
 #'
 #' # Note that if the replacements are not compatible with .x,
-#' # unmatched values are replaced by NA
+#' # unmatched values are replaced by NA and a warning is issued.
 #' recode(x, `2` = "b", `4` = "d")
 #'
 #' # If you don't name the arguments, recode() matches by position
@@ -58,6 +58,11 @@
 #' recode_factor(x, `1` = "z", `2` = "y", `3` = "x")
 #' recode_factor(x, `1` = "z", `2` = "y", .default = "D")
 #' recode_factor(x, `1` = "z", `2` = "y", .default = "D", .missing = "M")
+#'
+#' # When the input vector is a compatible vector (character vector or
+#' # factor), it is reused as default.
+#' recode_factor(letters[1:3], b = "z", c = "y")
+#' recode_factor(factor(letters[1:3]), b = "z", c = "y")
 recode <- function(.x, ..., .default = NULL, .missing = NULL) {
   UseMethod("recode")
 }

--- a/R/recode.R
+++ b/R/recode.R
@@ -91,7 +91,7 @@ recode.numeric <- function(.x, ..., .default = NULL, .missing = NULL) {
     replaced[.x == vals[i]] <- TRUE
   }
 
-  .default <- recode_default(.default, .x, out, replaced, recode_default_vector)
+  .default <- validate_recode_default(.default, .x, out, replaced)
   out <- replace_with(out, !replaced & !is.na(.x), .default, "`.default`")
   out <- replace_with(out, is.na(.x), .missing, "`.missing`")
   out
@@ -114,7 +114,7 @@ recode.character <- function(.x, ..., .default = NULL, .missing = NULL) {
     replaced[.x == nm] <- TRUE
   }
 
-  .default <- recode_default(.default, .x, out, replaced, recode_default_vector)
+  .default <- validate_recode_default(.default, .x, out, replaced)
   out <- replace_with(out, !replaced & !is.na(.x), .default, "`.default`")
   out <- replace_with(out, is.na(.x), .missing, "`.missing`")
   out
@@ -142,7 +142,7 @@ recode.factor <- function(.x, ..., .default = NULL, .missing = NULL) {
     replaced[levels(.x) == nm] <- TRUE
   }
 
-  .default <- recode_default(.default, .x, out, replaced, recode_default_factor)
+  .default <- validate_recode_default(.default, .x, out, replaced)
   out <- replace_with(out, !replaced, .default, "`.default`")
   levels(.x) <- out
 
@@ -159,18 +159,23 @@ find_template <- function(...) {
   x[[1]]
 }
 
-recode_default <- function(default, x, out, replaced, default_fun) {
-  default <- default_fun(default, x, out)
+validate_recode_default <- function(default, x, out, replaced) {
+  default <- recode_default(x, default, out)
 
   if (is.null(default) && sum(replaced & !is.na(x)) < length(out[!is.na(x)])) {
-    warning("Unreplaced values treated as NA as .x is not compatible
-  Please specify replacements exhaustively or supply .default")
+    warning("Unreplaced values treated as NA as .x is not compatible. ",
+      "Please specify replacements exhaustively or supply .default",
+      call. = FALSE)
   }
 
   default
 }
 
-recode_default_vector <- function(default, x, out) {
+recode_default <- function(x, default, out) {
+  UseMethod("recode_default")
+}
+
+recode_default.default <- function(x, default, out) {
   same_type <- identical(typeof(x), typeof(out))
   if (is.null(default) && same_type) {
     x
@@ -179,7 +184,7 @@ recode_default_vector <- function(default, x, out) {
   }
 }
 
-recode_default_factor <- function(default, x, out) {
+recode_default.factor <- function(x, default, out) {
   if (is.null(default) && is.factor(x)) {
     levels(x)
   } else {
@@ -193,7 +198,7 @@ recode_factor <- function (.x, ..., .default = NULL, .missing = NULL,
                            .ordered = FALSE) {
   recoded <- recode(.x, ..., .default = .default, .missing = .missing)
 
-  all_levels <- unique(c(..., recode_default_factor(.default, .x), .missing))
+  all_levels <- unique(c(..., recode_default(.x, .default, recoded), .missing))
   recoded_levels <- if (is.factor(recoded)) levels(recoded) else unique(recoded)
   levels <- intersect(all_levels, recoded_levels)
 

--- a/man/recode.Rd
+++ b/man/recode.Rd
@@ -56,7 +56,7 @@ x <- c(1:5, NA)
 recode(x, `2` = 20L, `4` = 40L)
 
 # Note that if the replacements are not compatible with .x,
-# unmatched values are replaced by NA
+# unmatched values are replaced by NA and a warning is issued.
 recode(x, `2` = "b", `4` = "d")
 
 # If you don't name the arguments, recode() matches by position
@@ -75,5 +75,10 @@ x <- c(1:4, NA)
 recode_factor(x, `1` = "z", `2` = "y", `3` = "x")
 recode_factor(x, `1` = "z", `2` = "y", .default = "D")
 recode_factor(x, `1` = "z", `2` = "y", .default = "D", .missing = "M")
+
+# When the input vector is a compatible vector (character vector or
+# factor), it is reused as default.
+recode_factor(letters[1:3], b = "z", c = "y")
+recode_factor(factor(letters[1:3]), b = "z", c = "y")
 }
 

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -71,9 +71,27 @@ test_that(".default is not aliased to .x when missing and not compatible", {
   expect_equal(recode(n, `1` = "a"), c("a", NA, NA))
 })
 
+test_that("default .default works with factors", {
+  expect_equal(recode(factor(letters[1:3]), a = "A"), factor(c("A", "b", "c")))
+})
+
 test_that("recode_factor() handles .missing and .default levels", {
   x <- c(1:3, NA)
   expect_equal(recode_factor(x, `1` = "z", `2` = "y"), factor(c("z", "y", NA, NA), levels = c("z", "y")))
   expect_equal(recode_factor(x, `1` = "z", `2` = "y", .default = "D"), factor(c("z", "y", "D", NA), levels = c("z", "y", "D")))
   expect_equal(recode_factor(x, `1` = "z", `2` = "y", .default = "D", .missing = "M"), factor(c("z", "y", "D", "M"), c("z", "y", "D", "M")))
+})
+
+test_that("recode_factor() handles vector .default", {
+  character_default <- recode_factor(factor(letters[1:3]), b = "z", c = "y", .default = letters[1:3])
+  implicit_factor_default <- recode_factor(factor(letters[1:3]), b = "z", c = "y")
+
+  expected <- factor(c("a", "z", "y"), levels = c("z", "y", "a"))
+  expect_equal(character_default, expected)
+  expect_equal(implicit_factor_default, expected)
+})
+
+test_that("can recode factor with redundant levels", {
+  expect_equal(recode(factor(letters[1:4]), d = "c", b = "a"), factor(c("a", "a", "c", "c"), levels = c("a", "c")))
+  expect_equal(recode_factor(letters[1:4], d = "c", b = "a"), factor(c("a", "a", "c", "c"), levels = c("c", "a")))
 })

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -85,10 +85,12 @@ test_that("recode_factor() handles .missing and .default levels", {
 test_that("recode_factor() handles vector .default", {
   character_default <- recode_factor(factor(letters[1:3]), b = "z", c = "y", .default = letters[1:3])
   implicit_factor_default <- recode_factor(factor(letters[1:3]), b = "z", c = "y")
+  implicit_character_default <- recode_factor(letters[1:3], b = "z", c = "y")
 
   expected <- factor(c("a", "z", "y"), levels = c("z", "y", "a"))
   expect_equal(character_default, expected)
   expect_equal(implicit_factor_default, expected)
+  expect_equal(implicit_character_default, expected)
 })
 
 test_that("can recode factor with redundant levels", {
@@ -98,4 +100,5 @@ test_that("can recode factor with redundant levels", {
 
 test_that("conversion of unreplaced values to NA gives warning", {
   expect_warning(recode(1:3, `1` = "a"), "treated as NA")
+  expect_warning(recode_factor(letters[1:3], b = 1, c = 2))
 })

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -35,7 +35,7 @@ test_that("missing values replaced by missing argument", {
 })
 
 test_that("unmatched value replaced by default argument", {
-  expect_equal(recode(c(1, 2), "a"), c("a", NA))
+  expect_warning(expect_equal(recode(c(1, 2), "a"), c("a", NA)))
   expect_equal(recode(c(1, 2), "a", .default = "b"), c("a", "b"))
 })
 
@@ -65,10 +65,10 @@ test_that(".default is aliased to .x when missing and compatible", {
 
 test_that(".default is not aliased to .x when missing and not compatible", {
   x <- letters[1:3]
-  expect_equal(recode(x, a = 1), c(1L, NA, NA))
+  expect_warning(expect_equal(recode(x, a = 1), c(1L, NA, NA)))
 
   n <- 1:3
-  expect_equal(recode(n, `1` = "a"), c("a", NA, NA))
+  expect_warning(expect_equal(recode(n, `1` = "a"), c("a", NA, NA)))
 })
 
 test_that("default .default works with factors", {
@@ -77,7 +77,7 @@ test_that("default .default works with factors", {
 
 test_that("recode_factor() handles .missing and .default levels", {
   x <- c(1:3, NA)
-  expect_equal(recode_factor(x, `1` = "z", `2` = "y"), factor(c("z", "y", NA, NA), levels = c("z", "y")))
+  expect_warning(expect_equal(recode_factor(x, `1` = "z", `2` = "y"), factor(c("z", "y", NA, NA), levels = c("z", "y"))))
   expect_equal(recode_factor(x, `1` = "z", `2` = "y", .default = "D"), factor(c("z", "y", "D", NA), levels = c("z", "y", "D")))
   expect_equal(recode_factor(x, `1` = "z", `2` = "y", .default = "D", .missing = "M"), factor(c("z", "y", "D", "M"), c("z", "y", "D", "M")))
 })
@@ -94,4 +94,8 @@ test_that("recode_factor() handles vector .default", {
 test_that("can recode factor with redundant levels", {
   expect_equal(recode(factor(letters[1:4]), d = "c", b = "a"), factor(c("a", "a", "c", "c"), levels = c("a", "c")))
   expect_equal(recode_factor(letters[1:4], d = "c", b = "a"), factor(c("a", "a", "c", "c"), levels = c("c", "a")))
+})
+
+test_that("conversion of unreplaced values to NA gives warning", {
+  expect_warning(recode(1:3, `1` = "a"), "treated as NA")
 })


### PR DESCRIPTION
This fixes a couple of issues for recoding factors:

- `recode.factor()` now uses `.x` as default when `.default` is NULL, just like the other methods

- `recode_factor()` handles vector default better