### PR TITLE
tolerate unknown vars in one_of()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 * enabling joining of data frames that don't have the same encoding of
   column names (#1513). 
+  
+* `one_of()` tolerates unknown variables in `vars`, but warns (#1848, @jennybc).
 
 ## Breaking changes
 

--- a/R/select-utils.R
+++ b/R/select-utils.R
@@ -7,7 +7,7 @@
 #'  \item \code{contains()}: contains a literal string
 #'  \item \code{matches()}: matches a regular expression
 #'  \item \code{num_range()}: a numerical range like x01, x02, x03.
-#'  \item \code{one_of()}: varables in character vector.
+#'  \item \code{one_of()}: variables in character vector.
 #'  \item \code{everything()}: all variables.
 #' }
 #'
@@ -116,7 +116,7 @@ one_of <- function(..., vars = current_vars()) {
 
   if (!all(keep %in% vars)) {
     bad <- setdiff(keep, vars)
-    stop("Unknown variables: ", paste0("`", bad, "`", collapse = ", "))
+    warning("Unknown variables: ", paste0("`", bad, "`", collapse = ", "))
   }
 
   match_vars(keep, vars)

--- a/man/select_helpers.Rd
+++ b/man/select_helpers.Rd
@@ -58,7 +58,7 @@ These functions allow you to select variables based on their names.
  \item \code{contains()}: contains a literal string
  \item \code{matches()}: matches a regular expression
  \item \code{num_range()}: a numerical range like x01, x02, x03.
- \item \code{one_of()}: varables in character vector.
+ \item \code{one_of()}: variables in character vector.
  \item \code{everything()}: all variables.
 }
 }

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -43,12 +43,17 @@ test_that("num_range selects numeric ranges", {
 # one_of ------------------------------------------------------------------
 
 test_that("one_of gives useful errors", {
+  expect_error(one_of(1L, vars = c("x", "y")), "must be a character vector")
+})
+
+test_that("one_of tolerates but warns for unknown variables", {
   vars <- c("x", "y")
 
-  expect_error(one_of("z", vars = vars), "Unknown variables: `z`")
-  expect_error(one_of(c("x", "z"), vars = vars), "Unknown variables: `z`")
+  expect_warning(res <- one_of("z", vars = vars), "Unknown variables: `z`")
+  expect_equal(res, -(1:2))
+  expect_warning(res <- one_of(c("x", "z"), vars = vars), "Unknown variables: `z`")
+  expect_equal(res, 1L)
 
-  expect_error(one_of(1L, vars = vars), "must be a character vector")
 })
 
 test_that("one_of converts names to positions", {


### PR DESCRIPTION
I want to say "if variable x is present, keep it; but don't worry if it's not" inside `dplyr::select()`. I have a pipeline where a certain variable will be there sometimes but not others.

```
select(head(iris, 3), one_of(c("Sepal.Length", "Stem.Length")))
#>   Sepal.Length
#> 1          5.1
#> 2          4.9
#> 3          4.7
#> Warning message:
#> In one_of(c("Sepal.Length", "Stem.Length")) :
#>   Unknown variables: `Stem.Length`
```