### PR TITLE
WIP: Change file name for in-memory SQLite database

### DIFF
--- a/R/data-temp.r
+++ b/R/data-temp.r
@@ -8,7 +8,7 @@
 #' @examples
 #' \dontrun{
 #' test_register_src("df", src_df(env = new.env()))
-#' test_register_src("sqlite", src_sqlite(":memory:", create = TRUE))
+#' test_register_src("sqlite", src_sqlite("file::memory:", create = TRUE))
 #'
 #' test_frame(x = 1:3, y = 3:1)
 #' test_load(mtcars)

--- a/R/manip.r
+++ b/R/manip.r
@@ -98,7 +98,7 @@ slice_ <- function(.data, ..., .dots) {
 #' by_cyl_dt <- mtcars %>% dtplyr::tbl_dt() %>% group_by(cyl)
 #' by_cyl_dt %>% summarise(a = n(), b = a + 1)
 #'
-#' by_cyl_db <- src_sqlite(":memory:", create = TRUE) %>%
+#' by_cyl_db <- src_sqlite("file::memory:", create = TRUE) %>%
 #'   copy_to(mtcars) %>% group_by(cyl)
 #' by_cyl_db %>% summarise(a = n(), b = a + 1)
 #' }

--- a/R/src-sqlite.r
+++ b/R/src-sqlite.r
@@ -123,7 +123,7 @@ src_sqlite <- function(path, create = FALSE) {
 #' df %>% arrange(x) %>% show_query()
 #' }
 src_memdb <- function() {
-  cache_computation("src_memdb", src_sqlite(":memory:", TRUE))
+  cache_computation("src_memdb", src_sqlite("file::memory:", TRUE))
 }
 
 #' @inheritParams tibble::data_frame

--- a/man/summarise.Rd
+++ b/man/summarise.Rd
@@ -55,7 +55,7 @@ by_cyl \%>\% summarise(a = n(), b = a + 1)
 by_cyl_dt <- mtcars \%>\% dtplyr::tbl_dt() \%>\% group_by(cyl)
 by_cyl_dt \%>\% summarise(a = n(), b = a + 1)
 
-by_cyl_db <- src_sqlite(":memory:", create = TRUE) \%>\%
+by_cyl_db <- src_sqlite("file::memory:", create = TRUE) \%>\%
   copy_to(mtcars) \%>\% group_by(cyl)
 by_cyl_db \%>\% summarise(a = n(), b = a + 1)
 }

--- a/man/testing.Rd
+++ b/man/testing.Rd
@@ -22,7 +22,7 @@ use \code{test_frame}.
 \examples{
 \dontrun{
 test_register_src("df", src_df(env = new.env()))
-test_register_src("sqlite", src_sqlite(":memory:", create = TRUE))
+test_register_src("sqlite", src_sqlite("file::memory:", create = TRUE))
 
 test_frame(x = 1:3, y = 3:1)
 test_load(mtcars)

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -1,5 +1,5 @@
 test_register_src("df", src_df(env = new.env(parent = emptyenv())))
-test_register_src("sqlite", src_sqlite(":memory:", create = TRUE))
+test_register_src("sqlite", src_sqlite("file::memory:", create = TRUE))
 
 if (identical(Sys.info()[["user"]], "hadley")) {
   test_register_src("postgres", src_postgres("test", host = "localhost"))

--- a/tests/testthat/test-union-all.R
+++ b/tests/testthat/test-union-all.R
@@ -13,7 +13,7 @@ test_that("union all on data frames calls bind rows", {
 
 test_that("union on database uses UNION ALL", {
   skip_if_no_sqlite()
-  db <- src_sqlite(":memory:", TRUE)
+  db <- src_sqlite("file::memory:", TRUE)
 
   df1 <- copy_to(db, data_frame(x = 1:2), "df1")
   df2 <- copy_to(db, data_frame(x = 1:2), "df2")


### PR DESCRIPTION
Use `"file::memory:"` instead of `":memory:"`, the latter doesn't seem to work well on Windows for unknown reasons.

This needs to wait for RSQLite > 1.0.0 to hit CRAN, because the CRAN version simply creates a file named `"file::memory:"`.