### PR TITLE
revert 04704bf to enable installing purrr again

### DIFF
--- a/inst/include/dplyr/DataFrameSubsetVisitors.h
+++ b/inst/include/dplyr/DataFrameSubsetVisitors.h
@@ -14,9 +14,43 @@ namespace dplyr {
         public:
             typedef SubsetVectorVisitor visitor_type ;
 
-            DataFrameSubsetVisitors( const Rcpp::DataFrame& data_)  ;
+            DataFrameSubsetVisitors( const Rcpp::DataFrame& data_) :
+                data(data_),
+                visitors(),
+                visitor_names(data.names()),
+                nvisitors(visitor_names.size())
+            {
 
-            DataFrameSubsetVisitors( const Rcpp::DataFrame& data_, const Rcpp::CharacterVector& names )  ;
+                for( int i=0; i<nvisitors; i++){
+                    SubsetVectorVisitor* v = subset_visitor( data[i] ) ;
+                    visitors.push_back(v) ;
+                }
+            }
+
+            DataFrameSubsetVisitors( const Rcpp::DataFrame& data_, const Rcpp::CharacterVector& names ) :
+                data(data_),
+                visitors(),
+                visitor_names(names),
+                nvisitors(visitor_names.size())
+            {
+
+                std::string name ;
+                int n = names.size() ;
+                for( int i=0; i<n; i++){
+                    name = (String)names[i] ;
+                    SEXP column ;
+
+                    try{
+                        column = data[name] ;
+                    } catch( ... ){
+                        stop( "unknown column '%s' ", name ) ;
+                    }
+                    SubsetVectorVisitor* v = subset_visitor( column ) ;
+                    visitors.push_back(v) ;
+
+                }
+
+            }
 
             template <typename Container>
             DataFrame subset_impl( const Container& index, const CharacterVector& classes, traits::false_type ) const {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -78,41 +78,6 @@ namespace dplyr{
         }
     }
 
-    DataFrameSubsetVisitors::DataFrameSubsetVisitors( const Rcpp::DataFrame& data_) :
-        data(data_),
-        visitors(),
-        visitor_names(data.names()),
-        nvisitors(visitor_names.size())
-    {
-
-        for( int i=0; i<nvisitors; i++){
-            SubsetVectorVisitor* v = subset_visitor( data[i] ) ;
-            visitors.push_back(v) ;
-        }
-    }
-
-    DataFrameSubsetVisitors::DataFrameSubsetVisitors( const Rcpp::DataFrame& data_, const Rcpp::CharacterVector& names ) :
-        data(data_),
-        visitors(),
-        visitor_names(names),
-        nvisitors(visitor_names.size())
-    {
-
-        std::string name ;
-        int n = names.size() ;
-        IntegerVector indices  = Language( "match", names,  RCPP_GET_NAMES(data)  ).fast_eval() ;
-
-        for( int i=0; i<n; i++){
-            int pos = indices[i] ;
-            if( pos == NA_INTEGER ){
-                name = (String)names[i] ;
-                stop( "unknown column '%s' ", name ) ;
-            }
-            visitors.push_back(subset_visitor( data[pos-1] )) ;
-        }
-    }
-
-
     Symbol extract_column( SEXP arg, const Environment& env ){
       RObject value ;
       if( TYPEOF(arg) == LANGSXP && CAR(arg) == Rf_install("~") ){


### PR DESCRIPTION
(Disclaimer: I'm not familiar with C++)

This temporarily fixes #1814.

As I wrote in #1814, this problem is about template class. Since the compiler compiles templates only with the types that are actually used, if the type purrr uses is not used in dplyr, it is not compiled and occurs `undefined reference to ...` error. In this case, exporting the class whole in header file is right way in my understanding.

So, could you consider reverting 04704bf for now? I know this may not be an ultimate solution, but not a few people must suffer from failing to install purrr with dev version of dplyr.