### PR TITLE
bind_rows() rejects POSIXlt columns

### DIFF
--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -379,7 +379,11 @@ namespace dplyr {
             return new Collecter_Impl<CPLXSXP>(n) ;
         case LGLSXP: return new Collecter_Impl<LGLSXP>(n) ;
         case STRSXP: return new Collecter_Impl<STRSXP>(n) ;
-        case VECSXP: return new Collecter_Impl<VECSXP>(n) ;
+        case VECSXP:
+            if( Rf_inherits( model, "POSIXlt" )) {
+                stop( "POSIXlt not supported" ) ;
+            }
+            return new Collecter_Impl<VECSXP>(n) ;
         default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(model))) ;
         }
         return 0 ;

--- a/inst/include/dplyr/Result/GroupedSubset.h
+++ b/inst/include/dplyr/Result/GroupedSubset.h
@@ -64,7 +64,11 @@ namespace dplyr {
             case LGLSXP: return new GroupedSubsetTemplate<LGLSXP>(x, max_size) ;
             case STRSXP: return new GroupedSubsetTemplate<STRSXP>(x, max_size) ;
             case VECSXP:
-                if( Rf_inherits(x, "data.frame") ) return new DataFrameGroupedSubset(x) ;
+                if( Rf_inherits( x, "data.frame" ) )
+                    return new DataFrameGroupedSubset(x) ;
+                if( Rf_inherits( x, "POSIXlt" ) ) {
+                    stop( "POSIXlt not supported" ) ;
+                }
                 return new GroupedSubsetTemplate<VECSXP>(x, max_size) ;
             case CPLXSXP: return new GroupedSubsetTemplate<CPLXSXP>(x, max_size) ;
             default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x)));

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -386,3 +386,9 @@ test_that("bind_cols infers classes from first result (#1692)", {
   expect_equal( class(bind_rows(d5,d1)), c("tbl_df", "tbl", "data.frame") )
 
 })
+
+test_that("bind_rows rejects POSIXlt columns (#1789)", {
+  df <- data_frame(x = Sys.time() + 1:12)
+  df$y <- as.POSIXlt(df$x)
+  expect_error(bind_rows(df, df), "not supported")
+})


### PR DESCRIPTION
instead of segfaulting.

Fixes #1789.

Also fixes another instance with the same pattern, but I'm not sure if this is strictly necessary.

NEWS line:

```
* `bind_rows()` cleanly aborts if one of the data frames contains a `POSIXlt` column
  (#1789, #1875, @krlmlr).
```