### PR TITLE
Valid R syntax for message printed when performing a natural join

### DIFF
--- a/R/join.r
+++ b/R/join.r
@@ -122,7 +122,7 @@ common_by <- function(by = NULL, x, y) {
   if (length(by) == 0) {
     stop("No common variables. Please specify `by` param.", call. = FALSE)
   }
-  message("Joining by: ", utils::capture.output(dput(by)))
+  message("Joining, by = ", utils::capture.output(dput(by)))
 
   list(
     x = by,


### PR DESCRIPTION
Now:

```
Joining, by = "a"
Joining, by = c("b", "c")
```

The user can copy the text starting at the comma until the end and just paste it into the join call.

Original issue: https://github.com/hadley/dplyr/issues/1783#issuecomment-221874823