### PR TITLE
Call stop() outside of switch() statement

### DIFF
--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -373,8 +373,10 @@ namespace dplyr {
                 stop( "POSIXlt not supported" ) ;
             }
             return new Collecter_Impl<VECSXP>(n) ;
-        default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(model))) ;
+        default: break ;
         }
+
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(model))) ;
         return 0 ;
     }
 
@@ -406,8 +408,9 @@ namespace dplyr {
           if( previous->is_factor_collecter() )
             Rf_warning("binding factor and character vector, coercing into character vector") ;
           return new Collecter_Impl<STRSXP>(n) ;
-        default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(model))) ;
+        default: break ;
         }
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(model))) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -274,8 +274,9 @@ namespace dplyr {
             case STRSXP:  return new ConstantGathererImpl<STRSXP>( x, n ) ;
             case CPLXSXP: return new ConstantGathererImpl<CPLXSXP>( x, n ) ;
             case VECSXP:  return new ConstantGathererImpl<STRSXP>( x, n ) ;
-            default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x))) ;
+            default: break ;
         }
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x))) ;
         return 0 ;
     }
 
@@ -309,9 +310,10 @@ namespace dplyr {
             case STRSXP:  return new GathererImpl<STRSXP,Data,Subsets>  ( first, indices, proxy, gdf, i ) ;
             case VECSXP:  return new ListGatherer<Data,Subsets>  ( List(first), indices, proxy, gdf, i ) ;
             case CPLXSXP: return new GathererImpl<CPLXSXP,Data,Subsets> ( first, indices, proxy, gdf, i ) ;
-            default: check_supported_type(first, name);
+            default: break ;
         }
-         ;
+
+        check_supported_type(first, name);
         return 0;
     }
 

--- a/inst/include/dplyr/Order.h
+++ b/inst/include/dplyr/Order.h
@@ -11,11 +11,8 @@ namespace dplyr {
         OrderVisitors( List args, LogicalVector ascending, int n_ ) :
             visitors(n_), n(n_), nrows(0){
             nrows = Rf_length( args[0] );
-            for( int i=0; i<n; i++){
-                OrderVisitor* v = order_visitor( args[i], ascending[i] ) ;
-                if( !v ) stop("Cannot order based on this column") ;
-                visitors[i]  = v ;
-            }
+            for( int i=0; i<n; i++)
+                visitors[i]  = order_visitor( args[i], ascending[i] );
         }
         OrderVisitors( DataFrame data ) :
             visitors(data.size()), n(data.size()), nrows( data.nrows() )

--- a/inst/include/dplyr/OrderVisitorImpl.h
+++ b/inst/include/dplyr/OrderVisitorImpl.h
@@ -184,7 +184,7 @@ namespace dplyr {
                     case LGLSXP:   return new OrderVisitorMatrix<LGLSXP  , true>( vec ) ;
                     case STRSXP:   return new OrderVisitorMatrix<STRSXP  , true>( vec ) ;
                     case CPLXSXP:  return new OrderVisitorMatrix<CPLXSXP , true>( vec ) ;
-                    default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
+                    default: break ;
                 }
             } else {
                 switch( TYPEOF(vec) ){
@@ -193,9 +193,10 @@ namespace dplyr {
                     case LGLSXP:   return new OrderVisitorMatrix<LGLSXP  , false>( vec ) ;
                     case STRSXP:   return new OrderVisitorMatrix<STRSXP  , false>( vec ) ;
                     case CPLXSXP:  return new OrderVisitorMatrix<CPLXSXP , false>( vec ) ;
-                    default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
+                    default: break ;
                 }
             }
+            stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
             return 0 ;
         }
 
@@ -213,7 +214,7 @@ namespace dplyr {
                         }
                         break ;
                     }
-                default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
+                default: break ;
             }
         } else {
             switch( TYPEOF(vec) ){
@@ -230,11 +231,11 @@ namespace dplyr {
                     break ;
                 }
 
-                default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
+                default: break ;
             }
         }
 
-        // should not happen
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
         return 0 ;
     }
 }

--- a/inst/include/dplyr/OrderVisitorImpl.h
+++ b/inst/include/dplyr/OrderVisitorImpl.h
@@ -184,7 +184,7 @@ namespace dplyr {
     OrderVisitor* order_visitor_asc_matrix( SEXP vec );
 
     template <bool ascending>
-    OrderVisitor* order_visitor_asc_data_frame( SEXP vec );
+    OrderVisitor* order_visitor_asc_vector( SEXP vec );
 
     inline OrderVisitor* order_visitor( SEXP vec, bool ascending ){
         if ( ascending ){
@@ -201,7 +201,7 @@ namespace dplyr {
             return order_visitor_asc_matrix<ascending>(vec) ;
         }
         else {
-            return order_visitor_asc_data_frame<ascending>(vec) ;
+            return order_visitor_asc_vector<ascending>(vec) ;
         }
     }
 
@@ -220,7 +220,7 @@ namespace dplyr {
     }
 
     template <bool ascending>
-    inline OrderVisitor* order_visitor_asc_data_frame( SEXP vec ) {
+    inline OrderVisitor* order_visitor_asc_vector( SEXP vec ) {
         switch( TYPEOF(vec) ){
             case INTSXP:  return new OrderVectorVisitorImpl<INTSXP , ascending, Vector<INTSXP > >( vec ) ;
             case REALSXP: return new OrderVectorVisitorImpl<REALSXP, ascending, Vector<REALSXP> >( vec ) ;

--- a/inst/include/dplyr/OrderVisitorImpl.h
+++ b/inst/include/dplyr/OrderVisitorImpl.h
@@ -175,64 +175,66 @@ namespace dplyr {
     } ;
 
 
-    inline OrderVisitor* order_visitor( SEXP vec, bool ascending ){
-        if( Rf_isMatrix(vec) ){
-            if(ascending) {
-                switch( TYPEOF(vec) ){
-                    case INTSXP:   return new OrderVisitorMatrix<INTSXP  , true>( vec ) ;
-                    case REALSXP:  return new OrderVisitorMatrix<REALSXP , true>( vec ) ;
-                    case LGLSXP:   return new OrderVisitorMatrix<LGLSXP  , true>( vec ) ;
-                    case STRSXP:   return new OrderVisitorMatrix<STRSXP  , true>( vec ) ;
-                    case CPLXSXP:  return new OrderVisitorMatrix<CPLXSXP , true>( vec ) ;
-                    default: break ;
-                }
-            } else {
-                switch( TYPEOF(vec) ){
-                    case INTSXP:   return new OrderVisitorMatrix<INTSXP  , false>( vec ) ;
-                    case REALSXP:  return new OrderVisitorMatrix<REALSXP , false>( vec ) ;
-                    case LGLSXP:   return new OrderVisitorMatrix<LGLSXP  , false>( vec ) ;
-                    case STRSXP:   return new OrderVisitorMatrix<STRSXP  , false>( vec ) ;
-                    case CPLXSXP:  return new OrderVisitorMatrix<CPLXSXP , false>( vec ) ;
-                    default: break ;
-                }
-            }
-            stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
-            return 0 ;
-        }
+    inline OrderVisitor* order_visitor( SEXP vec, bool ascending );
 
-        if( ascending ){
-            switch( TYPEOF(vec) ){
-                case INTSXP:  return new OrderVectorVisitorImpl<INTSXP , true, Vector<INTSXP > >( vec ) ;
-                case REALSXP: return new OrderVectorVisitorImpl<REALSXP, true, Vector<REALSXP> >( vec ) ;
-                case LGLSXP:  return new OrderVectorVisitorImpl<LGLSXP , true, Vector<LGLSXP > >( vec ) ;
-                case STRSXP:  return new OrderCharacterVectorVisitorImpl<true>( vec ) ;
-                case CPLXSXP:  return new OrderVectorVisitorImpl<CPLXSXP , true, Vector<CPLXSXP > >( vec ) ;
-                case VECSXP:
-                    {
-                        if( Rf_inherits( vec, "data.frame" ) ){
-                            return new OrderVisitorDataFrame<true>( vec ) ;
-                        }
-                        break ;
-                    }
-                default: break ;
-            }
-        } else {
-            switch( TYPEOF(vec) ){
-                case INTSXP:  return new OrderVectorVisitorImpl<INTSXP , false, Vector<INTSXP > >( vec ) ;
-                case REALSXP: return new OrderVectorVisitorImpl<REALSXP, false, Vector<REALSXP> >( vec ) ;
-                case LGLSXP:  return new OrderVectorVisitorImpl<LGLSXP , false, Vector<LGLSXP > >( vec ) ;
-                case STRSXP:  return new OrderCharacterVectorVisitorImpl<false>( vec ) ;
-                case CPLXSXP:  return new OrderVectorVisitorImpl<CPLXSXP , false, Vector<CPLXSXP > >( vec ) ;
-                case VECSXP:
+    template <bool ascending>
+    OrderVisitor* order_visitor_asc( SEXP vec );
+
+    template <bool ascending>
+    OrderVisitor* order_visitor_asc_matrix( SEXP vec );
+
+    template <bool ascending>
+    OrderVisitor* order_visitor_asc_data_frame( SEXP vec );
+
+    inline OrderVisitor* order_visitor( SEXP vec, bool ascending ){
+        if ( ascending ){
+            return order_visitor_asc<true>(vec);
+        }
+        else {
+            return order_visitor_asc<false>(vec);
+        }
+    }
+
+    template <bool ascending>
+    inline OrderVisitor* order_visitor_asc( SEXP vec ) {
+        if( Rf_isMatrix(vec) ){
+            return order_visitor_asc_matrix<ascending>(vec) ;
+        }
+        else {
+            return order_visitor_asc_data_frame<ascending>(vec) ;
+        }
+    }
+
+    template <bool ascending>
+    inline OrderVisitor* order_visitor_asc_matrix( SEXP vec ) {
+        switch( TYPEOF(vec) ){
+            case INTSXP:   return new OrderVisitorMatrix<INTSXP  , ascending>( vec ) ;
+            case REALSXP:  return new OrderVisitorMatrix<REALSXP , ascending>( vec ) ;
+            case LGLSXP:   return new OrderVisitorMatrix<LGLSXP  , ascending>( vec ) ;
+            case STRSXP:   return new OrderVisitorMatrix<STRSXP  , ascending>( vec ) ;
+            case CPLXSXP:  return new OrderVisitorMatrix<CPLXSXP , ascending>( vec ) ;
+            default: break ;
+        }
+        stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
+        return 0 ;
+    }
+
+    template <bool ascending>
+    inline OrderVisitor* order_visitor_asc_data_frame( SEXP vec ) {
+        switch( TYPEOF(vec) ){
+            case INTSXP:  return new OrderVectorVisitorImpl<INTSXP , ascending, Vector<INTSXP > >( vec ) ;
+            case REALSXP: return new OrderVectorVisitorImpl<REALSXP, ascending, Vector<REALSXP> >( vec ) ;
+            case LGLSXP:  return new OrderVectorVisitorImpl<LGLSXP , ascending, Vector<LGLSXP > >( vec ) ;
+            case STRSXP:  return new OrderCharacterVectorVisitorImpl<ascending>( vec ) ;
+            case CPLXSXP:  return new OrderVectorVisitorImpl<CPLXSXP , ascending, Vector<CPLXSXP > >( vec ) ;
+            case VECSXP:
                 {
                     if( Rf_inherits( vec, "data.frame" ) ){
-                        return new OrderVisitorDataFrame<false>( vec ) ;
+                        return new OrderVisitorDataFrame<ascending>( vec ) ;
                     }
                     break ;
                 }
-
-                default: break ;
-            }
+            default: break ;
         }
 
         stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;

--- a/inst/include/dplyr/Replicator.h
+++ b/inst/include/dplyr/Replicator.h
@@ -43,9 +43,10 @@ namespace dplyr {
             case STRSXP:   return new ReplicatorImpl<STRSXP , Data> ( v, n, gdf.ngroups() ) ;
             case LGLSXP:   return new ReplicatorImpl<LGLSXP , Data> ( v, n, gdf.ngroups() ) ;
             case CPLXSXP:  return new ReplicatorImpl<CPLXSXP, Data> ( v, n, gdf.ngroups() ) ;
-            default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(v))) ;
+            default: break ;
         }
 
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(v))) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/Result/GroupedSubset.h
+++ b/inst/include/dplyr/Result/GroupedSubset.h
@@ -71,8 +71,9 @@ namespace dplyr {
                 }
                 return new GroupedSubsetTemplate<VECSXP>(x, max_size) ;
             case CPLXSXP: return new GroupedSubsetTemplate<CPLXSXP>(x, max_size) ;
-            default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x)));
+            default: break ;
         }
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x))) ;
         return 0 ;
     }
 
@@ -129,8 +130,9 @@ namespace dplyr {
             case STRSXP: return new SummarisedSubsetTemplate<STRSXP>(x, max_size) ;
             case VECSXP: return new SummarisedSubsetTemplate<VECSXP>(x, max_size) ;
             case CPLXSXP: return new SummarisedSubsetTemplate<CPLXSXP>(x, max_size) ;
-            default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x)));
+            default: break ;
         }
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x))) ;
         return 0 ;
     }
 }

--- a/inst/include/dplyr/Result/RowwiseSubset.h
+++ b/inst/include/dplyr/Result/RowwiseSubset.h
@@ -75,8 +75,9 @@ namespace dplyr {
             case STRSXP: return new RowwiseSubsetTemplate<STRSXP>(x) ;
             case CPLXSXP: return new RowwiseSubsetTemplate<CPLXSXP>(x) ;
             case VECSXP: return new RowwiseSubsetTemplate<VECSXP>(x) ;
-            default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x)));
+            default: break ;
         }
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(x))) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/subset_visitor.h
+++ b/inst/include/dplyr/subset_visitor.h
@@ -13,8 +13,10 @@ namespace dplyr {
             case LGLSXP:  return new MatrixColumnSubsetVisitor<LGLSXP>( vec ) ;
             case STRSXP:  return new MatrixColumnSubsetVisitor<STRSXP>( vec ) ;
             case VECSXP:  return new MatrixColumnSubsetVisitor<VECSXP>( vec ) ;
-            default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec)));
+            default: break ;
             }
+
+            stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
         }
 
         if( Rf_inherits(vec, "Date") ){
@@ -41,10 +43,11 @@ namespace dplyr {
                     }
                     return new SubsetVectorVisitorImpl<VECSXP>( vec ) ;
             }
-            default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec)));
+            default: break ;
         }
 
-        // should not happen
+        // should not happen, safeguard against segfaults anyway
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/subset_visitor.h
+++ b/inst/include/dplyr/subset_visitor.h
@@ -3,53 +3,65 @@
 
 namespace dplyr {
 
-    inline SubsetVectorVisitor* subset_visitor( SEXP vec ){
+inline SubsetVectorVisitor* subset_visitor_matrix( SEXP vec );
+inline SubsetVectorVisitor* subset_visitor_data_frame( SEXP vec );
 
-        if( Rf_isMatrix( vec ) ){
-            switch( TYPEOF(vec) ){
-            case CPLXSXP: return new MatrixColumnSubsetVisitor<CPLXSXP>( vec ) ;
-            case INTSXP:  return new MatrixColumnSubsetVisitor<INTSXP>( vec ) ;
-            case REALSXP: return new MatrixColumnSubsetVisitor<REALSXP>( vec ) ;
-            case LGLSXP:  return new MatrixColumnSubsetVisitor<LGLSXP>( vec ) ;
-            case STRSXP:  return new MatrixColumnSubsetVisitor<STRSXP>( vec ) ;
-            case VECSXP:  return new MatrixColumnSubsetVisitor<VECSXP>( vec ) ;
-            default: break ;
-            }
+inline SubsetVectorVisitor* subset_visitor( SEXP vec ){
+  if( Rf_isMatrix( vec ) ){
+    return subset_visitor_matrix(vec) ;
+  }
+  else {
+    return subset_visitor_data_frame(vec) ;
+  }
+}
 
-            stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
-        }
+inline SubsetVectorVisitor* subset_visitor_matrix( SEXP vec ){
+  switch( TYPEOF(vec) ){
+  case CPLXSXP: return new MatrixColumnSubsetVisitor<CPLXSXP>( vec ) ;
+  case INTSXP:  return new MatrixColumnSubsetVisitor<INTSXP>( vec ) ;
+  case REALSXP: return new MatrixColumnSubsetVisitor<REALSXP>( vec ) ;
+  case LGLSXP:  return new MatrixColumnSubsetVisitor<LGLSXP>( vec ) ;
+  case STRSXP:  return new MatrixColumnSubsetVisitor<STRSXP>( vec ) ;
+  case VECSXP:  return new MatrixColumnSubsetVisitor<VECSXP>( vec ) ;
+  default: break ;
+  }
 
-        if( Rf_inherits(vec, "Date") ){
-            return new DateSubsetVectorVisitor(vec) ;
-        }
+  stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
+  return 0 ;
+}
 
-        switch( TYPEOF(vec) ){
-            case CPLXSXP:
-                return new SubsetVectorVisitorImpl<CPLXSXP>( vec ) ;
-            case INTSXP:
-                if( Rf_inherits(vec, "factor" ))
-                    return new SubsetFactorVisitor( vec ) ;
-                return new SubsetVectorVisitorImpl<INTSXP>( vec ) ;
-            case REALSXP: return new SubsetVectorVisitorImpl<REALSXP>( vec ) ;
-            case LGLSXP:  return new SubsetVectorVisitorImpl<LGLSXP>( vec ) ;
-            case STRSXP:  return new SubsetVectorVisitorImpl<STRSXP>( vec ) ;
+inline SubsetVectorVisitor* subset_visitor_data_frame( SEXP vec ){
+  if( Rf_inherits(vec, "Date") ){
+    return new DateSubsetVectorVisitor(vec) ;
+  }
 
-            case VECSXP:  {
-                    if( Rf_inherits( vec, "data.frame" ) ){
-                        return new DataFrameColumnSubsetVisitor(vec) ;
-                    }
-                    if( Rf_inherits( vec, "POSIXlt" )) {
-                        stop( "POSIXlt not supported" ) ;
-                    }
-                    return new SubsetVectorVisitorImpl<VECSXP>( vec ) ;
-            }
-            default: break ;
-        }
+  switch( TYPEOF(vec) ){
+  case CPLXSXP:
+    return new SubsetVectorVisitorImpl<CPLXSXP>( vec ) ;
+  case INTSXP:
+    if( Rf_inherits(vec, "factor" ))
+      return new SubsetFactorVisitor( vec ) ;
+    return new SubsetVectorVisitorImpl<INTSXP>( vec ) ;
+  case REALSXP: return new SubsetVectorVisitorImpl<REALSXP>( vec ) ;
+  case LGLSXP:  return new SubsetVectorVisitorImpl<LGLSXP>( vec ) ;
+  case STRSXP:  return new SubsetVectorVisitorImpl<STRSXP>( vec ) ;
 
-        // should not happen, safeguard against segfaults anyway
-        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
-        return 0 ;
+  case VECSXP:  {
+    if( Rf_inherits( vec, "data.frame" ) ){
+    return new DataFrameColumnSubsetVisitor(vec) ;
+  }
+    if( Rf_inherits( vec, "POSIXlt" )) {
+      stop( "POSIXlt not supported" ) ;
     }
+    return new SubsetVectorVisitorImpl<VECSXP>( vec ) ;
+  }
+  default: break ;
+  }
+
+  // should not happen, safeguard against segfaults anyway
+  stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
+  return 0 ;
+}
 
 }
 

--- a/inst/include/dplyr/subset_visitor.h
+++ b/inst/include/dplyr/subset_visitor.h
@@ -47,14 +47,14 @@ inline SubsetVectorVisitor* subset_visitor_vector( SEXP vec ){
   case STRSXP:  return new SubsetVectorVisitorImpl<STRSXP>( vec ) ;
 
   case VECSXP:  {
-    if( Rf_inherits( vec, "data.frame" ) ){
-    return new DataFrameColumnSubsetVisitor(vec) ;
-  }
-    if( Rf_inherits( vec, "POSIXlt" )) {
-      stop( "POSIXlt not supported" ) ;
+      if( Rf_inherits( vec, "data.frame" ) ){
+        return new DataFrameColumnSubsetVisitor(vec) ;
+      }
+      if( Rf_inherits( vec, "POSIXlt" )) {
+        stop( "POSIXlt not supported" ) ;
+      }
+      return new SubsetVectorVisitorImpl<VECSXP>( vec ) ;
     }
-    return new SubsetVectorVisitorImpl<VECSXP>( vec ) ;
-  }
   default: break ;
   }
 

--- a/inst/include/dplyr/subset_visitor.h
+++ b/inst/include/dplyr/subset_visitor.h
@@ -4,14 +4,14 @@
 namespace dplyr {
 
 inline SubsetVectorVisitor* subset_visitor_matrix( SEXP vec );
-inline SubsetVectorVisitor* subset_visitor_data_frame( SEXP vec );
+inline SubsetVectorVisitor* subset_visitor_vector( SEXP vec );
 
 inline SubsetVectorVisitor* subset_visitor( SEXP vec ){
   if( Rf_isMatrix( vec ) ){
     return subset_visitor_matrix(vec) ;
   }
   else {
-    return subset_visitor_data_frame(vec) ;
+    return subset_visitor_vector(vec) ;
   }
 }
 
@@ -30,7 +30,7 @@ inline SubsetVectorVisitor* subset_visitor_matrix( SEXP vec ){
   return 0 ;
 }
 
-inline SubsetVectorVisitor* subset_visitor_data_frame( SEXP vec ){
+inline SubsetVectorVisitor* subset_visitor_vector( SEXP vec ){
   if( Rf_inherits(vec, "Date") ){
     return new DateSubsetVectorVisitor(vec) ;
   }

--- a/inst/include/dplyr/visitor.h
+++ b/inst/include/dplyr/visitor.h
@@ -4,14 +4,14 @@
 namespace dplyr {
 
 inline VectorVisitor* visitor_matrix( SEXP vec ) ;
-inline VectorVisitor* visitor_data_frame( SEXP vec ) ;
+inline VectorVisitor* visitor_vector( SEXP vec ) ;
 
 inline VectorVisitor* visitor( SEXP vec ){
   if( Rf_isMatrix( vec ) ){
     return visitor_matrix(vec) ;
   }
   else {
-    return visitor_data_frame(vec) ;
+    return visitor_vector(vec) ;
   }
 }
 
@@ -30,7 +30,7 @@ inline VectorVisitor* visitor_matrix( SEXP vec ){
   return 0 ;
 }
 
-inline VectorVisitor* visitor_data_frame( SEXP vec ){
+inline VectorVisitor* visitor_vector( SEXP vec ){
   switch( TYPEOF(vec) ){
   case CPLXSXP:
     return new VectorVisitorImpl<CPLXSXP>( vec ) ;

--- a/inst/include/dplyr/visitor.h
+++ b/inst/include/dplyr/visitor.h
@@ -44,14 +44,14 @@ inline VectorVisitor* visitor_vector( SEXP vec ){
   case STRSXP:  return new VectorVisitorImpl<STRSXP>( vec ) ;
 
   case VECSXP:  {
-    if( Rf_inherits( vec, "data.frame" ) ){
-    return new DataFrameColumnVisitor(vec) ;
-  }
-    if( Rf_inherits( vec, "POSIXlt" )) {
-      stop( "POSIXlt not supported" ) ;
+      if( Rf_inherits( vec, "data.frame" ) ){
+        return new DataFrameColumnVisitor(vec) ;
+      }
+      if( Rf_inherits( vec, "POSIXlt" )) {
+        stop( "POSIXlt not supported" ) ;
+      }
+      return new VectorVisitorImpl<VECSXP>( vec ) ;
     }
-    return new VectorVisitorImpl<VECSXP>( vec ) ;
-  }
   default: break ;
   }
 

--- a/inst/include/dplyr/visitor.h
+++ b/inst/include/dplyr/visitor.h
@@ -13,8 +13,10 @@ namespace dplyr {
             case LGLSXP: return new MatrixColumnVisitor<LGLSXP>( vec ) ;
             case STRSXP: return new MatrixColumnVisitor<STRSXP>( vec ) ;
             case VECSXP: return new MatrixColumnVisitor<VECSXP>( vec ) ;
-            default: stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec)));
-          }
+            default: break ;
+            }
+
+            stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
         }
 
         switch( TYPEOF(vec) ){
@@ -38,10 +40,11 @@ namespace dplyr {
                     }
                     return new VectorVisitorImpl<VECSXP>( vec ) ;
             }
-            default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec)));
+            default: break ;
         }
 
-        // should not happen
+        // should not happen, safeguard against segfaults anyway
+        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
         return 0 ;
     }
 

--- a/inst/include/dplyr/visitor.h
+++ b/inst/include/dplyr/visitor.h
@@ -3,50 +3,62 @@
 
 namespace dplyr {
 
-    inline VectorVisitor* visitor( SEXP vec ){
+inline VectorVisitor* visitor_matrix( SEXP vec ) ;
+inline VectorVisitor* visitor_data_frame( SEXP vec ) ;
 
-        if( Rf_isMatrix( vec ) ){
-            switch( TYPEOF(vec) ){
-            case CPLXSXP: return new MatrixColumnVisitor<CPLXSXP>( vec ) ;
-            case INTSXP: return new MatrixColumnVisitor<INTSXP>( vec ) ;
-            case REALSXP: return new MatrixColumnVisitor<REALSXP>( vec ) ;
-            case LGLSXP: return new MatrixColumnVisitor<LGLSXP>( vec ) ;
-            case STRSXP: return new MatrixColumnVisitor<STRSXP>( vec ) ;
-            case VECSXP: return new MatrixColumnVisitor<VECSXP>( vec ) ;
-            default: break ;
-            }
+inline VectorVisitor* visitor( SEXP vec ){
+  if( Rf_isMatrix( vec ) ){
+    return visitor_matrix(vec) ;
+  }
+  else {
+    return visitor_data_frame(vec) ;
+  }
+}
 
-            stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
-        }
+inline VectorVisitor* visitor_matrix( SEXP vec ){
+  switch( TYPEOF(vec) ){
+  case CPLXSXP: return new MatrixColumnVisitor<CPLXSXP>( vec ) ;
+  case INTSXP: return new MatrixColumnVisitor<INTSXP>( vec ) ;
+  case REALSXP: return new MatrixColumnVisitor<REALSXP>( vec ) ;
+  case LGLSXP: return new MatrixColumnVisitor<LGLSXP>( vec ) ;
+  case STRSXP: return new MatrixColumnVisitor<STRSXP>( vec ) ;
+  case VECSXP: return new MatrixColumnVisitor<VECSXP>( vec ) ;
+  default: break ;
+  }
 
-        switch( TYPEOF(vec) ){
-            case CPLXSXP:
-                return new VectorVisitorImpl<CPLXSXP>( vec ) ;
-            case INTSXP:
-                if( Rf_inherits(vec, "factor" ))
-                    return new FactorVisitor( vec ) ;
-                return new VectorVisitorImpl<INTSXP>( vec ) ;
-            case REALSXP:
-                return new VectorVisitorImpl<REALSXP>( vec ) ;
-            case LGLSXP:  return new VectorVisitorImpl<LGLSXP>( vec ) ;
-            case STRSXP:  return new VectorVisitorImpl<STRSXP>( vec ) ;
+  stop("Unsupported matrix type %s", Rf_type2char(TYPEOF(vec))) ;
+  return 0 ;
+}
 
-            case VECSXP:  {
-                    if( Rf_inherits( vec, "data.frame" ) ){
-                        return new DataFrameColumnVisitor(vec) ;
-                    }
-                    if( Rf_inherits( vec, "POSIXlt" )) {
-                        stop( "POSIXlt not supported" ) ;
-                    }
-                    return new VectorVisitorImpl<VECSXP>( vec ) ;
-            }
-            default: break ;
-        }
+inline VectorVisitor* visitor_data_frame( SEXP vec ){
+  switch( TYPEOF(vec) ){
+  case CPLXSXP:
+    return new VectorVisitorImpl<CPLXSXP>( vec ) ;
+  case INTSXP:
+    if( Rf_inherits(vec, "factor" ))
+      return new FactorVisitor( vec ) ;
+    return new VectorVisitorImpl<INTSXP>( vec ) ;
+  case REALSXP:
+    return new VectorVisitorImpl<REALSXP>( vec ) ;
+  case LGLSXP:  return new VectorVisitorImpl<LGLSXP>( vec ) ;
+  case STRSXP:  return new VectorVisitorImpl<STRSXP>( vec ) ;
 
-        // should not happen, safeguard against segfaults anyway
-        stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
-        return 0 ;
+  case VECSXP:  {
+    if( Rf_inherits( vec, "data.frame" ) ){
+    return new DataFrameColumnVisitor(vec) ;
+  }
+    if( Rf_inherits( vec, "POSIXlt" )) {
+      stop( "POSIXlt not supported" ) ;
     }
+    return new VectorVisitorImpl<VECSXP>( vec ) ;
+  }
+  default: break ;
+  }
+
+  // should not happen, safeguard against segfaults anyway
+  stop("Unsupported vector type %s", Rf_type2char(TYPEOF(vec))) ;
+  return 0 ;
+}
 
 }
 

--- a/src/nth.cpp
+++ b/src/nth.cpp
@@ -81,8 +81,9 @@ Result* nth_with( Vector<RTYPE> data, int idx, SEXP order ){
       case INTSXP: return new NthWith<RTYPE, INTSXP>( data, idx, order );
       case REALSXP: return new NthWith<RTYPE, REALSXP>( data, idx, order );
       case STRSXP: return new NthWith<RTYPE, STRSXP>( data, idx, order );
-      default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(order)));
+      default: break ;
     }
+    stop("Unsupported vector type %s", Rf_type2char(TYPEOF(order))) ;
     return 0 ;
 }
 
@@ -93,8 +94,9 @@ Result* nth_with_default( Vector<RTYPE> data, int idx, SEXP order, Vector<RTYPE>
       case INTSXP: return new NthWith<RTYPE, INTSXP>( data, idx, order, def[0] );
       case REALSXP: return new NthWith<RTYPE, REALSXP>( data, idx, order, def[0] );
       case STRSXP: return new NthWith<RTYPE, STRSXP>( data, idx, order, def[0] );
-      default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(order)));
+      default: break ;
     }
+    stop("Unsupported vector type %s", Rf_type2char(TYPEOF(order))) ;
     return 0 ;
 }
 
@@ -134,7 +136,7 @@ Result* nth_prototype( SEXP call, const LazySubsets& subsets, int nargs){
         case REALSXP: return new Nth<REALSXP>(data, idx) ;
         case STRSXP: return new Nth<STRSXP>(data, idx) ;
         case LGLSXP: return new Nth<LGLSXP>(data, idx) ;
-        default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(data)));
+        default: break ;
         }
     } else {
         // now get `order_by` and default
@@ -172,8 +174,11 @@ Result* nth_prototype( SEXP call, const LazySubsets& subsets, int nargs){
                     case INTSXP:  return nth_with<INTSXP>( data, idx, order_by ) ;
                     case REALSXP: return nth_with<REALSXP>( data, idx, order_by ) ;
                     case STRSXP:  return nth_with<STRSXP>( data, idx, order_by ) ;
-                    default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(data)));
+                    default: break ;
                 }
+            }
+            else {
+                return 0;
             }
 
 
@@ -184,7 +189,7 @@ Result* nth_prototype( SEXP call, const LazySubsets& subsets, int nargs){
                     case INTSXP:  return nth_noorder_default<INTSXP>(data, idx, def) ;
                     case REALSXP: return nth_noorder_default<REALSXP>(data, idx, def) ;
                     case STRSXP:  return nth_noorder_default<STRSXP>(data, idx, def) ;
-                    default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(data)));
+                    default: break ;
                 }
             } else {
                 if( TYPEOF(order_by) == SYMSXP && subsets.count(order_by) ){
@@ -195,14 +200,18 @@ Result* nth_prototype( SEXP call, const LazySubsets& subsets, int nargs){
                         case INTSXP:  return nth_with_default<INTSXP>(data, idx, order_by, def) ;
                         case REALSXP: return nth_with_default<REALSXP>(data, idx, order_by, def) ;
                         case STRSXP: return nth_with_default<STRSXP>(data, idx, order_by, def) ;
-                        default: stop("Unsupported vector type %s", Rf_type2char(TYPEOF(data)));
+                        default: break ;
                     }
+                }
+                else {
+                    return 0;
                 }
 
             }
         }
 
     }
+    stop("Unsupported vector type %s", Rf_type2char(TYPEOF(data))) ;
     return 0;
 }
 

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -147,7 +147,7 @@ test_that("arrange fails gracefully on list columns (#1489)", {
   df <- expand.grid(group = 1:2, y = 1, x = 1) %>%
     group_by(group) %>%
     do(fit = lm(data = ., y ~ x))
-  expect_error( arrange(df, fit), "Cannot order based on this column" )
+  expect_error( arrange(df, fit), "Unsupported vector type list" )
 })
 
 test_that("arrange fails gracefully on raw columns (#1803)", {


### PR DESCRIPTION
so that break works inside switch() without surprises

https://github.com/hadley/dplyr/pull/1875#issuecomment-223000740

Working on further cleanup based on this commit. Also looking for a way to generalize the omnipresent switch(): http://stackoverflow.com/q/37576790/946850.