### PR TITLE
Expanded and corrected backend DB doc

### DIFF
--- a/R/dbi-s3.r
+++ b/R/dbi-s3.r
@@ -30,20 +30,45 @@ sql_translate_env.NULL <- function(con) {
 
 #' Database generics.
 #'
-#' These generics execute actions on the database. All generics have a method
+#' These generics execute actions on the database. Most generics have a method
 #' for \code{DBIConnection} which typically just call the standard DBI S4
 #' method.
 #'
-#' @section copy_to:
-#' Currently, the only user of \code{sql_begin()}, \code{sql_commit()},
-#' \code{sql_rollback()}, \code{sql_create_table()}, \code{sql_insert_into()},
-#' \code{sql_create_indexes()}, \code{sql_drop_table()} and
-#' \code{sql_analyze()}. If you find yourself overriding many of these
+#' Note, a few backend methods do not call the standard DBI S4 methods including
+#' \itemize{
+#' \item \code{db_data_type}: Calls DBI's \code{dbDataType} for every field
+#' (e.g. data frame column) and returns a vector of corresponding SQL data
+#' types
+#' \item \code{db_save_query}: Builds and executes \code{CREATE [TEMPORARY]
+#' TABLE <table> ...} SQL command.
+#' \item \code{db_create_table}: Builds and executes \code{CREATE [TEMPORARY]
+#' TABLE <table> ...} SQL command.
+#' \item \code{db_create_index}: Builds and executes \code{CREATE INDEX <name>
+#' ON <table>} SQL command.
+#' \item \code{db_drop_table}: Builds and executes \code{DROP TABLE [IF EXISTS]
+#'  <table>} SQL command.
+#' \item \code{db_analyze}: Builds and executes \code{ANALYZE <table>} SQL
+#' command.
+#' \item \code{db_insert_into} and \code{db_explain}: do not have methods
+#' calling corresponding DBI methods. The latter because no underlying DBI S4
+#' method exists and the former because calls to the corresponding DBI S4
+#' method (\code{dbWriteTable}) need to be able to specify an appropriate
+#' combination of values for non-standard \code{append} and \code{overwrite}
+#' arguments.
+#' }
+#'
+#' Currently, \code{copy_to} is the only user of \code{db_begin()}, \code{db_commit()},
+#' \code{db_rollback()}, \code{db_create_table()}, \code{db_insert_into()},
+#' \code{db_create_indexes()}, \code{db_drop_table()} and
+#' \code{db_analyze()}. If you find yourself overriding many of these
 #' functions it may suggest that you should just override \code{\link{copy_to}}
 #' instead.
 #'
-#' @return A logical value indicating success. Most failures should generate
-#'  an error.
+#' @return Usually a logical value indicating success. Most failures should generate
+#'  an error. However, \code{db_has_table()} should return \code{NA} if
+#'  temporary tables cannot be listed with \code{dbListTables} (due to backend
+#'  API limitations for example). As a result, you methods will rely on the
+#'  backend to throw an error if a table exists when it shouldn't.
 #' @name backend_db
 #' @param con A database connection.
 #' @keywords internal

--- a/man/backend_db.Rd
+++ b/man/backend_db.Rd
@@ -57,20 +57,45 @@ db_query_rows(con, sql, ...)
 \item{fields}{A list of fields, as in a data frame.}
 }
 \value{
-A logical value indicating success. Most failures should generate
- an error.
+Usually a logical value indicating success. Most failures should generate
+ an error. However, \code{db_has_table()} should return \code{NA} if
+ temporary tables cannot be listed with \code{dbListTables} (due to backend
+ API limitations for example). As a result, you methods will rely on the
+ backend to throw an error if a table exists when it shouldn't.
 }
 \description{
-These generics execute actions on the database. All generics have a method
+These generics execute actions on the database. Most generics have a method
 for \code{DBIConnection} which typically just call the standard DBI S4
 method.
 }
-\section{copy_to}{
+\details{
+Note, a few backend methods do not call the standard DBI S4 methods including
+\itemize{
+\item \code{db_data_type}: Calls DBI's \code{dbDataType} for every field
+(e.g. data frame column) and returns a vector of corresponding SQL data
+types
+\item \code{db_save_query}: Builds and executes \code{CREATE [TEMPORARY]
+TABLE <table> ...} SQL command.
+\item \code{db_create_table}: Builds and executes \code{CREATE [TEMPORARY]
+TABLE <table> ...} SQL command.
+\item \code{db_create_index}: Builds and executes \code{CREATE INDEX <name>
+ON <table>} SQL command.
+\item \code{db_drop_table}: Builds and executes \code{DROP TABLE [IF EXISTS]
+ <table>} SQL command.
+\item \code{db_analyze}: Builds and executes \code{ANALYZE <table>} SQL
+command.
+\item \code{db_insert_into} and \code{db_explain}: do not have methods
+calling corresponding DBI methods. The latter because no underlying DBI S4
+method exists and the former because calls to the corresponding DBI S4
+method (\code{dbWriteTable}) need to be able to specify an appropriate
+combination of values for non-standard \code{append} and \code{overwrite}
+arguments.
+}
 
-Currently, the only user of \code{sql_begin()}, \code{sql_commit()},
-\code{sql_rollback()}, \code{sql_create_table()}, \code{sql_insert_into()},
-\code{sql_create_indexes()}, \code{sql_drop_table()} and
-\code{sql_analyze()}. If you find yourself overriding many of these
+Currently, \code{copy_to} is the only user of \code{db_begin()}, \code{db_commit()},
+\code{db_rollback()}, \code{db_create_table()}, \code{db_insert_into()},
+\code{db_create_indexes()}, \code{db_drop_table()} and
+\code{db_analyze()}. If you find yourself overriding many of these
 functions it may suggest that you should just override \code{\link{copy_to}}
 instead.
 }


### PR DESCRIPTION
Closes #1910. Summary:

* Have clarified which methods are thin wrappers for DBI methods; which ones build and execute their own SQL code (and summarised what this SQL code); and which do not have methods.
* Corrected return value doc. Though what I have put could be refined somewhat.
* Fixed references to sql_* functions to db_* where appropriate 
* I have not documented details of db_create_indexes because this is not exported. See #1911