### PR TITLE
Make db_create_indexes generic; export

### DIFF
--- a/R/dbi-s3.r
+++ b/R/dbi-s3.r
@@ -30,20 +30,45 @@ sql_translate_env.NULL <- function(con) {
 
 #' Database generics.
 #'
-#' These generics execute actions on the database. All generics have a method
+#' These generics execute actions on the database. Most generics have a method
 #' for \code{DBIConnection} which typically just call the standard DBI S4
 #' method.
 #'
-#' @section copy_to:
-#' Currently, the only user of \code{sql_begin()}, \code{sql_commit()},
-#' \code{sql_rollback()}, \code{sql_create_table()}, \code{sql_insert_into()},
-#' \code{sql_create_indexes()}, \code{sql_drop_table()} and
-#' \code{sql_analyze()}. If you find yourself overriding many of these
+#' Note, a few backend methods do not call the standard DBI S4 methods including
+#' \itemize{
+#' \item \code{db_data_type}: Calls DBI's \code{dbDataType} for every field
+#' (e.g. data frame column) and returns a vector of corresponding SQL data
+#' types
+#' \item \code{db_save_query}: Builds and executes \code{CREATE [TEMPORARY]
+#' TABLE <table> ...} SQL command.
+#' \item \code{db_create_table}: Builds and executes \code{CREATE [TEMPORARY]
+#' TABLE <table> ...} SQL command.
+#' \item \code{db_create_index}: Builds and executes \code{CREATE INDEX <name>
+#' ON <table>} SQL command.
+#' \item \code{db_drop_table}: Builds and executes \code{DROP TABLE [IF EXISTS]
+#'  <table>} SQL command.
+#' \item \code{db_analyze}: Builds and executes \code{ANALYZE <table>} SQL
+#' command.
+#' \item \code{db_insert_into} and \code{db_explain}: do not have methods
+#' calling corresponding DBI methods. The latter because no underlying DBI S4
+#' method exists and the former because calls to the corresponding DBI S4
+#' method (\code{dbWriteTable}) need to be able to specify an appropriate
+#' combination of values for non-standard \code{append} and \code{overwrite}
+#' arguments.
+#' }
+#'
+#' Currently, \code{copy_to} is the only user of \code{db_begin()}, \code{db_commit()},
+#' \code{db_rollback()}, \code{db_create_table()}, \code{db_insert_into()},
+#' \code{db_create_indexes()}, \code{db_drop_table()} and
+#' \code{db_analyze()}. If you find yourself overriding many of these
 #' functions it may suggest that you should just override \code{\link{copy_to}}
 #' instead.
 #'
-#' @return A logical value indicating success. Most failures should generate
-#'  an error.
+#' @return Usually a logical value indicating success. Most failures should generate
+#'  an error. However, \code{db_has_table()} should return \code{NA} if
+#'  temporary tables cannot be listed with \code{dbListTables} (due to backend
+#'  API limitations for example). As a result, you methods will rely on the
+#'  backend to throw an error if a table exists when it shouldn't.
 #' @name backend_db
 #' @param con A database connection.
 #' @keywords internal

--- a/R/dbi-s3.r
+++ b/R/dbi-s3.r
@@ -131,7 +131,15 @@ db_insert_into <- function(con, table, values, ...) {
   UseMethod("db_insert_into")
 }
 
+#' @name backend_db
+#' @export
 db_create_indexes <- function(con, table, indexes = NULL, unique = FALSE, ...) {
+  UseMethod("db_create_indexes")
+}
+
+#' @export
+db_create_indexes.DBIConnection <- function(con, table, indexes = NULL,
+  unique = FALSE, ...) {
   if (is.null(indexes)) return()
   assert_that(is.list(indexes))
 

--- a/man/backend_db.Rd
+++ b/man/backend_db.Rd
@@ -57,20 +57,45 @@ db_query_rows(con, sql, ...)
 \item{fields}{A list of fields, as in a data frame.}
 }
 \value{
-A logical value indicating success. Most failures should generate
- an error.
+Usually a logical value indicating success. Most failures should generate
+ an error. However, \code{db_has_table()} should return \code{NA} if
+ temporary tables cannot be listed with \code{dbListTables} (due to backend
+ API limitations for example). As a result, you methods will rely on the
+ backend to throw an error if a table exists when it shouldn't.
 }
 \description{
-These generics execute actions on the database. All generics have a method
+These generics execute actions on the database. Most generics have a method
 for \code{DBIConnection} which typically just call the standard DBI S4
 method.
 }
-\section{copy_to}{
+\details{
+Note, a few backend methods do not call the standard DBI S4 methods including
+\itemize{
+\item \code{db_data_type}: Calls DBI's \code{dbDataType} for every field
+(e.g. data frame column) and returns a vector of corresponding SQL data
+types
+\item \code{db_save_query}: Builds and executes \code{CREATE [TEMPORARY]
+TABLE <table> ...} SQL command.
+\item \code{db_create_table}: Builds and executes \code{CREATE [TEMPORARY]
+TABLE <table> ...} SQL command.
+\item \code{db_create_index}: Builds and executes \code{CREATE INDEX <name>
+ON <table>} SQL command.
+\item \code{db_drop_table}: Builds and executes \code{DROP TABLE [IF EXISTS]
+ <table>} SQL command.
+\item \code{db_analyze}: Builds and executes \code{ANALYZE <table>} SQL
+command.
+\item \code{db_insert_into} and \code{db_explain}: do not have methods
+calling corresponding DBI methods. The latter because no underlying DBI S4
+method exists and the former because calls to the corresponding DBI S4
+method (\code{dbWriteTable}) need to be able to specify an appropriate
+combination of values for non-standard \code{append} and \code{overwrite}
+arguments.
+}
 
-Currently, the only user of \code{sql_begin()}, \code{sql_commit()},
-\code{sql_rollback()}, \code{sql_create_table()}, \code{sql_insert_into()},
-\code{sql_create_indexes()}, \code{sql_drop_table()} and
-\code{sql_analyze()}. If you find yourself overriding many of these
+Currently, \code{copy_to} is the only user of \code{db_begin()}, \code{db_commit()},
+\code{db_rollback()}, \code{db_create_table()}, \code{db_insert_into()},
+\code{db_create_indexes()}, \code{db_drop_table()} and
+\code{db_analyze()}. If you find yourself overriding many of these
 functions it may suggest that you should just override \code{\link{copy_to}}
 instead.
 }


### PR DESCRIPTION
Closes #1911 and **this PR builds on PR #1915** (updating DB backend function docs).

Copied text from #1911 (for convenience): 

> Backends that require implementations of copy_to need to be able to access db_create_indexes. As this is not currently exported, backends will need to take a copy of this into their own code base. This seems unnecessary as there is nothing backend specific about this (simple for loop wrapper of db_create_index)