### PR TITLE
Allow fractional number of rows for head() for SQL sources

### DIFF
--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -65,7 +65,7 @@ sql_select.default <- function(con, select, from, where = NULL,
 
   if (!is.null(limit)) {
     assert_that(is.numeric(limit), length(limit) == 1L)
-    out$limit <- build_sql("LIMIT ", limit, con = con)
+    out$limit <- build_sql("LIMIT ", trunc(limit), con = con)
   }
 
   escape(unname(compact(out)), collapse = "\n", parens = FALSE, con = con)

--- a/tests/testthat/test-sql-render.R
+++ b/tests/testthat/test-sql-render.R
@@ -60,6 +60,14 @@ test_that("head limits rows returned", {
   expect_equal(nrow(out), 10)
 })
 
+test_that("head accepts fractional input", {
+  out <- memdb_frame(x = 1:100) %>%
+    head(10.5) %>%
+    collect()
+
+  expect_equal(nrow(out), 10)
+})
+
 
 test_that("mutate overwrites previous variables", {
   df <- memdb_frame(x = 1:5) %>%


### PR DESCRIPTION
With test.