### PR TITLE
Test data tables as part of the generic tests

### DIFF
--- a/R/dplyr.r
+++ b/R/dplyr.r
@@ -26,3 +26,6 @@
 #' @importFrom Rcpp cppFunction Rcpp.plugin.maker
 #' @importFrom stats setNames update
 NULL
+
+# Needed for data.table tests, but don't need to export
+.datatable.aware <- TRUE

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -1,4 +1,5 @@
 test_register_src("df", src_df(env = new.env(parent = emptyenv())))
+test_register_src("dt", dtplyr::src_dt(env = new.env(parent = emptyenv())))
 test_register_src("sqlite", src_sqlite(":memory:", create = TRUE))
 
 if (identical(Sys.info()[["user"]], "hadley")) {

--- a/tests/testthat/test-compute.R
+++ b/tests/testthat/test-compute.R
@@ -22,8 +22,10 @@ test_that("compute can create indexes", {
                compare = equal_data_frame, convert = TRUE)
   # FIXME: Reenable Postgres when it starts throwing errors on execution
   # failures
+  # FIXME: Reenable dt after implementing indexes and unique_indexes args
+  # to compute()
   compare_tbls(
-    tbls[!(names(tbls) %in% c("df", "postgres"))],
+    tbls[!(names(tbls) %in% c("df", "dt", "postgres"))],
     function(tbl) {
       expect_error(compute(tbl, unique_indexes = "z"), ".")
       expect_error(compute(tbl, indexes = "x", unique_indexes = "z"))

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -6,8 +6,7 @@ df <- data.frame(
   z = c(1, 1, 2, 2)
 )
 
-# FIXME: Reenable once distinct_.data.table gets .keep_all argument
-tbls <- test_load(df, ignore = "dt")
+tbls <- test_load(df)
 
 test_that("distinct equivalent to local unique when keep_all is TRUE", {
   compare_tbls(tbls, function(x) x %>% distinct(x, y, z, .keep_all = TRUE), ref = unique(df))

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -5,7 +5,9 @@ df <- data.frame(
   y = c(1, 1, 2, 2),
   z = c(1, 1, 2, 2)
 )
-tbls <- test_load(df)
+
+# FIXME: Reenable once distinct_.data.table gets .keep_all argument
+tbls <- test_load(df, ignore = "dt")
 
 test_that("distinct equivalent to local unique when keep_all is TRUE", {
   compare_tbls(tbls, function(x) x %>% distinct(x, y, z, .keep_all = TRUE), ref = unique(df))


### PR DESCRIPTION
Had to disable two tests for data.table-s, and to install the .datatable.aware symbol in the namespace.