### PR TITLE
test_register_src() always succeeds

### DIFF
--- a/R/data-temp.r
+++ b/R/data-temp.r
@@ -20,8 +20,14 @@ NULL
 #' @export
 #' @rdname testing
 test_register_src <- function(name, src) {
-  message("Registering testing src: ", name)
-  test_srcs$add(name, src)
+  message("Registering testing src: ", name, " ", appendLF = FALSE)
+  tryCatch(
+    {
+      test_srcs$add(name, src)
+      message("OK")
+    },
+    error = function(e) message(conditionMessage(e))
+  )
 }
 
 #' @export


### PR DESCRIPTION
and prints a message if source is unavailable. Helpers now seem to be executed by devtools::load_all(), too -- this adds a little safety.