### PR TITLE
Fix distinct() for SQL sources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,9 @@
 
 * `distinct()` now only keeps the distinct variables. If you want to return
   all variables (using the first row for non-distinct values) use
-  `.keep_all = TRUE` (#1110). (The default behaviour of using all variables
+  `.keep_all = TRUE` (#1110). For SQL sources, `.keep_all = FALSE` is
+  implemented using `GROUP BY`, and `.keep_all = TRUE` raises an error
+  (#1937, #1942, @krlmlr). (The default behaviour of using all variables
   when none are specified remains - this note only applies if you select
   some variables).
 

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -142,15 +142,24 @@ sql_build.op_filter <- function(op, con, ...) {
 
 #' @export
 sql_build.op_distinct <- function(op, con, ...) {
-  if (length(op$dots) > 0 && !op$args$.keep_all) {
-    stop("Can't calculate distinct only on specified columns with SQL",
-      call. = FALSE)
-  }
+  if (length(op$dots) == 0) {
+    select_query(
+      sql_build(op$x, con),
+      distinct = TRUE
+    )
+  } else {
+    if (op$args$.keep_all) {
+      stop("Can't calculate distinct only on specified columns with SQL unless .keep_all is FALSE",
+           call. = FALSE)
+    }
 
-  select_query(
-    sql_build(op$x, con),
-    distinct = TRUE
-  )
+    group_vars <- c.sql(ident(names(op$dots)), con = con)
+    select_query(
+      sql_build(op$x, con),
+      select = group_vars,
+      group_by = group_vars
+    )
+  }
 }
 
 # Dual table ops --------------------------------------------------------

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -11,6 +11,11 @@ test_that("distinct equivalent to local unique when keep_all is TRUE", {
   compare_tbls(tbls, function(x) x %>% distinct(), ref = unique(df))
 })
 
+test_that("distinct for single column works as expected (#1937)", {
+  compare_tbls(tbls, function(x) x %>% distinct(x, .keep_all = FALSE), ref = df[1, "x", drop= FALSE])
+  compare_tbls(tbls, function(x) x %>% distinct(y, .keep_all = FALSE), ref = df[c(1, 3), "y", drop= FALSE])
+})
+
 test_that("distinct throws error if column is specified and .keep_all is TRUE", {
   skip_if_no_sqlite()
   expect_error(collect(distinct(tbls$sqlite, x, .keep_all = TRUE)),

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -3,17 +3,18 @@ context("Distinct")
 df <- data.frame(
   x = c(1, 1, 1, 1),
   y = c(1, 1, 2, 2),
-  z = c(1, 1, 2, 2)
+  z = c(1, 2, 1, 2)
 )
 tbls <- test_load(df)
 
 test_that("distinct equivalent to local unique when keep_all is TRUE", {
-  compare_tbls(tbls, function(x) x %>% distinct(x, y, z, .keep_all = TRUE), ref = unique(df))
+  compare_tbls(tbls, function(x) x %>% distinct(), ref = unique(df))
 })
 
-test_that("distinct removes duplicates (sql)", {
+test_that("distinct throws error if column is specified and .keep_all is TRUE", {
   skip_if_no_sqlite()
-  expect_error(collect(distinct(tbls$sqlite, x)), "specified columns")
+  expect_error(collect(distinct(tbls$sqlite, x, .keep_all = TRUE)),
+               "specified columns")
 })
 
 test_that("distinct works for 0-sized columns (#1437)", {

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -19,7 +19,7 @@ test_that("distinct for single column works as expected (#1937)", {
 test_that("distinct throws error if column is specified and .keep_all is TRUE", {
   skip_if_no_sqlite()
   expect_error(collect(distinct(tbls$sqlite, x, .keep_all = TRUE)),
-               "specified columns")
+               "specified columns.*[.]keep_all")
 })
 
 test_that("distinct works for 0-sized columns (#1437)", {

--- a/tests/testthat/test-sql-render.R
+++ b/tests/testthat/test-sql-render.R
@@ -45,11 +45,17 @@ test_that("select can rename", {
 })
 
 test_that("distinct adds DISTINCT suffix", {
-  out <- memdb_frame(x = c(1, 1)) %>%
-    distinct() %>%
-    collect()
+  out <- memdb_frame(x = c(1, 1)) %>% distinct()
 
-  expect_equal(out, data_frame(x = 1))
+  expect_match(out %>% sql_render(), "SELECT DISTINCT")
+  expect_equal(out %>% collect(), data_frame(x = 1))
+})
+
+test_that("distinct over columns uses GROUP BY", {
+  out <- memdb_frame(x = c(1, 2), y = c(1, 1)) %>% distinct(y)
+
+  expect_match(out %>% sql_render(), "SELECT `y`.*GROUP BY `y`")
+  expect_equal(out %>% collect(), data_frame(y = 1))
 })
 
 test_that("head limits rows returned", {


### PR DESCRIPTION
Without columns:

- `.keep_all` is ignored if no columns are selected

With columns:

- `.keep_all = FALSE` is implemented using a grouped select
- `.keep_all = TRUE` still raises an error, because DISTINCT syntax seems to vary between SQL dialects

Adapted tests.

Fixes #1937.

