### PR TITLE
Hand-format limit when rendering SQL

### DIFF
--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -65,7 +65,9 @@ sql_select.default <- function(con, select, from, where = NULL,
 
   if (!is.null(limit)) {
     assert_that(is.numeric(limit), length(limit) == 1L)
-    out$limit <- build_sql("LIMIT ", trunc(limit), con = con)
+    out$limit <- build_sql("LIMIT ",
+                           sql(format(trunc(limit), scientific = FALSE)),
+                           con = con)
   }
 
   escape(unname(compact(out)), collapse = "\n", parens = FALSE, con = con)

--- a/tests/testthat/test-sql-render.R
+++ b/tests/testthat/test-sql-render.R
@@ -68,6 +68,21 @@ test_that("head accepts fractional input", {
   expect_equal(nrow(out), 10)
 })
 
+test_that("head renders to integer fractional input", {
+  out <- memdb_frame(x = 1:100) %>%
+    head(10.5) %>%
+    sql_render()
+
+  expect_match(out, "LIMIT 10$")
+})
+
+test_that("head works with huge whole numbers", {
+  out <- memdb_frame(x = 1:100) %>%
+    head(1e10) %>%
+    collect()
+
+  expect_equal(out, data_frame(x = 1:100))
+})
 
 test_that("mutate overwrites previous variables", {
   df <- memdb_frame(x = 1:5) %>%


### PR DESCRIPTION
to support limits > 2³¹ and to ensure that no decimal point is added to the SQL.

Follow-up to #1929.

See https://github.com/hannesmuehleisen/MonetDBLite/issues/56#issuecomment-227065094.