### PR TITLE
AppVeyor testing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@ demo/pandas
 ^revdep$
 ^README-.*\.png$
 ^codecov\.yml$
+^appveyor\.yml$

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,6 +17,7 @@ knitr::opts_chunk$set(
 # dplyr
 
 [![Build Status](https://travis-ci.org/hadley/dplyr.png?branch=master)](https://travis-ci.org/hadley/dplyr)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/hadley/dplyr?branch=master&svg=true)](https://ci.appveyor.com/project/hadley/dplyr)
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/dplyr)](http://cran.r-project.org/package=dplyr)
 [![Coverage Status](https://img.shields.io/codecov/c/github/hadley/dplyr/master.svg)](https://codecov.io/github/hadley/dplyr?branch=master)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_github hadley/devtools rstats-db/RSQLite
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,16 @@ install:
 
 # Adapt as necessary starting from here
 
+environment:
+  global:
+    WARNINGS_ARE_ERRORS: 1
+
+  matrix:
+  - R_VERSION: devel
+    R_ARCH: x64
+
+  - R_VERSION: patched
+
 build_script:
   - travis-tool.sh install_github hadley/devtools rstats-db/RSQLite
   - travis-tool.sh install_deps

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -238,6 +238,8 @@ test_that( "group_by supports column (#1012)", {
 })
 
 test_that("group_by handles encodings (#1507)", {
+  skip_on_os("windows") # 1950
+
   df <- data.frame(x=1:3, Eng=2:4)
   names(df) <- enc2utf8(c("\u00e9", "Eng"))
   res <- group_by_(df, iconv("\u00e9", from = "UTF-8", to = "latin1") )

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -352,7 +352,7 @@ test_that("row_number handles empty data frames (#762)", {
 })
 
 test_that("no utf8 invasion (#722)", {
-  skip_on_cran()
+  skip_on_os("windows")
 
   source("utf-8.R", local = TRUE)
 })


### PR DESCRIPTION
to prepare for release.

Also remove NOTE that occurs with RSQLite 1.0.0 (current CRAN version), check now succeeds with both CRAN and bleeding-edge RSQLite.

Closes #1949 (=includes it).

Please visit https://ci.appveyor.com to enable testing.

Passes win-builder tests, too.