### PR TITLE
tibble > 1.0 compatibility

### DIFF
--- a/tests/testthat/helper-output.R
+++ b/tests/testthat/helper-output.R
@@ -1,0 +1,5 @@
+output_file <- function(filename) file.path("output", filename)
+
+expect_output_file_rel <- function(x, filename) {
+  expect_output_file(x, output_file(filename), update = TRUE)
+}

--- a/tests/testthat/output/iris--70.txt
+++ b/tests/testthat/output/iris--70.txt
@@ -1,5 +1,5 @@
 Source:   query [?? x 5]
-Database: sqlite 3.11.1 [:memory:]
+Database: sqlite x.y.z [:memory:]
 
    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
           <dbl>       <dbl>        <dbl>       <dbl>   <chr>

--- a/tests/testthat/output/iris--70.txt
+++ b/tests/testthat/output/iris--70.txt
@@ -1,0 +1,16 @@
+Source:   query [?? x 5]
+Database: sqlite 3.11.1 [:memory:]
+
+   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
+          <dbl>       <dbl>        <dbl>       <dbl>   <chr>
+1           5.1         3.5          1.4         0.2  setosa
+2           4.9         3.0          1.4         0.2  setosa
+3           4.7         3.2          1.3         0.2  setosa
+4           4.6         3.1          1.5         0.2  setosa
+5           5.0         3.6          1.4         0.2  setosa
+6           5.4         3.9          1.7         0.4  setosa
+7           4.6         3.4          1.4         0.3  setosa
+8           5.0         3.4          1.5         0.2  setosa
+9           4.4         2.9          1.4         0.2  setosa
+10          4.9         3.1          1.5         0.1  setosa
+# ... with more rows

--- a/tests/testthat/output/iris-3-5.txt
+++ b/tests/testthat/output/iris-3-5.txt
@@ -1,0 +1,20 @@
+Source:   query [?? x 5]
+Database: sqlite 3.11.1 [:memory:]
+
+  Sepal.Length
+         <dbl>
+1          5.1
+2          4.9
+3          4.7
+# ...
+#   with
+#   more
+#   rows,
+#   and
+#   4
+#   more
+#   variables:
+#   Sepal.Width <dbl>,
+#   Petal.Length <dbl>,
+#   Petal.Width <dbl>,
+#   Species <chr>

--- a/tests/testthat/output/iris-3-5.txt
+++ b/tests/testthat/output/iris-3-5.txt
@@ -1,5 +1,5 @@
 Source:   query [?? x 5]
-Database: sqlite 3.11.1 [:memory:]
+Database: sqlite x.y.z [:memory:]
 
   Sepal.Length
          <dbl>

--- a/tests/testthat/output/iris-5-30.txt
+++ b/tests/testthat/output/iris-5-30.txt
@@ -1,5 +1,5 @@
 Source:   query [?? x 5]
-Database: sqlite 3.11.1 [:memory:]
+Database: sqlite x.y.z [:memory:]
 
   Sepal.Length Sepal.Width
          <dbl>       <dbl>

--- a/tests/testthat/output/iris-5-30.txt
+++ b/tests/testthat/output/iris-5-30.txt
@@ -1,0 +1,15 @@
+Source:   query [?? x 5]
+Database: sqlite 3.11.1 [:memory:]
+
+  Sepal.Length Sepal.Width
+         <dbl>       <dbl>
+1          5.1         3.5
+2          4.9         3.0
+3          4.7         3.2
+4          4.6         3.1
+5          5.0         3.6
+# ... with more rows, and 3
+#   more variables:
+#   Petal.Length <dbl>,
+#   Petal.Width <dbl>,
+#   Species <chr>

--- a/tests/testthat/output/iris-head-30-80.txt
+++ b/tests/testthat/output/iris-head-30-80.txt
@@ -1,0 +1,11 @@
+Source:   query [?? x 5]
+Database: sqlite 3.11.1 [:memory:]
+
+  Sepal.Length Sepal.Width Petal.Length Petal.Width Species
+         <dbl>       <dbl>        <dbl>       <dbl>   <chr>
+1          5.1         3.5          1.4         0.2  setosa
+2          4.9         3.0          1.4         0.2  setosa
+3          4.7         3.2          1.3         0.2  setosa
+4          4.6         3.1          1.5         0.2  setosa
+5          5.0         3.6          1.4         0.2  setosa
+6          5.4         3.9          1.7         0.4  setosa

--- a/tests/testthat/output/iris-head-30-80.txt
+++ b/tests/testthat/output/iris-head-30-80.txt
@@ -1,5 +1,5 @@
 Source:   query [?? x 5]
-Database: sqlite 3.11.1 [:memory:]
+Database: sqlite x.y.z [:memory:]
 
   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
          <dbl>       <dbl>        <dbl>       <dbl>   <chr>

--- a/tests/testthat/output/mtcars-8-30.txt
+++ b/tests/testthat/output/mtcars-8-30.txt
@@ -1,0 +1,19 @@
+Source:   query [?? x 11]
+Database: sqlite 3.11.1 [:memory:]
+
+    mpg   cyl  disp    hp
+  <dbl> <dbl> <dbl> <dbl>
+1  21.0     6 160.0   110
+2  21.0     6 160.0   110
+3  22.8     4 108.0    93
+4  21.4     6 258.0   110
+5  18.7     8 360.0   175
+6  18.1     6 225.0   105
+7  14.3     8 360.0   245
+8  24.4     4 146.7    62
+# ... with more rows, and 7
+#   more variables:
+#   drat <dbl>, wt <dbl>,
+#   qsec <dbl>, vs <dbl>,
+#   am <dbl>, gear <dbl>,
+#   carb <dbl>

--- a/tests/testthat/output/mtcars-8-30.txt
+++ b/tests/testthat/output/mtcars-8-30.txt
@@ -1,5 +1,5 @@
 Source:   query [?? x 11]
-Database: sqlite 3.11.1 [:memory:]
+Database: sqlite x.y.z [:memory:]
 
     mpg   cyl  disp    hp
   <dbl> <dbl> <dbl> <dbl>

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -136,11 +136,11 @@ test_that("arrange respects locale (#1280)", {
 test_that("duplicated column name is explicit about which column (#996)", {
     df <- data.frame( x = 1:10, x = 1:10 )
     names(df) <- c("x", "x")
-    expect_error( df %>% arrange, "found duplicated column name: x" )
+    expect_error( df %>% arrange, "found duplicated column name: x|unique name.*'x'" )
 
     df <- data.frame( x = 1:10, x = 1:10, y = 1:10, y = 1:10 )
     names(df) <- c("x", "x", "y", "y")
-    expect_error( df %>% arrange, "found duplicated column name: x, y" )
+    expect_error( df %>% arrange, "found duplicated column name: x, y|unique name.*'x', 'y'" )
 })
 
 test_that("arrange fails gracefully on list columns (#1489)", {

--- a/tests/testthat/test-as-data-frame.R
+++ b/tests/testthat/test-as-data-frame.R
@@ -12,6 +12,9 @@ test_that("as.data.frame works for SQL sources", {
 })
 
 test_that("as_data_frame works for SQL sources", {
+  if (packageVersion("tibble") < "1.0-4")
+    skip("need tibble 1.0-4 or later for this test")
+
   lf1 <- memdb_frame(x = letters)
   out <- lf1 %>%
     as_data_frame()
@@ -29,6 +32,9 @@ test_that("as.data.frame is unlimited", {
 })
 
 test_that("as_data_frame is unlimited", {
+  if (packageVersion("tibble") < "1.0-4")
+    skip("need tibble 1.0-4 or later for this test")
+
   x <- rep(1:2, formals(collect.tbl_sql)$n)
   lf1 <- memdb_frame(x = x)
   out <- lf1 %>%

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -192,7 +192,7 @@ X
   datesDF$X <- as.POSIXlt(datesDF$X)
   expect_error(
     filter(datesDF, X > as.POSIXlt("2014-03-13")),
-    "column 'X' has unsupported class"
+    "column 'X' has unsupported class|POSIXct, not POSIXlt.*'X'"
   )
 })
 

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -1,6 +1,9 @@
 context("output")
 
 test_that("ungrouped output", {
+  if (packageVersion("tibble") < "1.0-10")
+    skip("need tibble 1.0-10 or later for this test")
+
   mtcars_mem <- src_memdb() %>% copy_to(mtcars, name = random_table_name())
   iris_mem <- src_memdb() %>% copy_to(iris, name = random_table_name())
 

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -1,0 +1,26 @@
+context("output")
+
+test_that("ungrouped output", {
+  mtcars_mem <- src_memdb() %>% copy_to(mtcars, name = random_table_name())
+  iris_mem <- src_memdb() %>% copy_to(iris, name = random_table_name())
+
+  expect_output_file_rel(
+    print(mtcars_mem, n = 8L, width = 30L),
+    "mtcars-8-30.txt")
+
+  expect_output_file_rel(
+    print(iris_mem, n = 5L, width = 30L),
+    "iris-5-30.txt")
+
+  expect_output_file_rel(
+    print(iris_mem, n = 3L, width = 5L),
+    "iris-3-5.txt")
+
+  expect_output_file_rel(
+    print(iris_mem, n = NULL, width = 70L),
+    "iris--70.txt")
+
+  expect_output_file_rel(
+    print(iris_mem %>% head(), n = 30L, width = 80L),
+    "iris-head-30-80.txt")
+})

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -7,23 +7,28 @@ test_that("ungrouped output", {
   mtcars_mem <- src_memdb() %>% copy_to(mtcars, name = random_table_name())
   iris_mem <- src_memdb() %>% copy_to(iris, name = random_table_name())
 
-  expect_output_file_rel(
-    print(mtcars_mem, n = 8L, width = 30L),
-    "mtcars-8-30.txt")
+  with_mock(
+    `dplyr::sqlite_version` = function() "x.y.z",
+    {
+      expect_output_file_rel(
+        print(mtcars_mem, n = 8L, width = 30L),
+        "mtcars-8-30.txt")
 
-  expect_output_file_rel(
-    print(iris_mem, n = 5L, width = 30L),
-    "iris-5-30.txt")
+      expect_output_file_rel(
+        print(iris_mem, n = 5L, width = 30L),
+        "iris-5-30.txt")
 
-  expect_output_file_rel(
-    print(iris_mem, n = 3L, width = 5L),
-    "iris-3-5.txt")
+      expect_output_file_rel(
+        print(iris_mem, n = 3L, width = 5L),
+        "iris-3-5.txt")
 
-  expect_output_file_rel(
-    print(iris_mem, n = NULL, width = 70L),
-    "iris--70.txt")
+      expect_output_file_rel(
+        print(iris_mem, n = NULL, width = 70L),
+        "iris--70.txt")
 
-  expect_output_file_rel(
-    print(iris_mem %>% head(), n = 30L, width = 80L),
-    "iris-head-30-80.txt")
+      expect_output_file_rel(
+        print(iris_mem %>% head(), n = 30L, width = 80L),
+        "iris-head-30-80.txt")
+    }
+  )
 })


### PR DESCRIPTION
All tests now succeed with *both* CRAN and bleeding-edge tibble, to faciliate dplyr CRAN release.