### PR TITLE
Support zero-column corner case in vector visitors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -346,8 +346,9 @@ There were two other tweaks to the exported API, but these are less likely to af
 
 * Hybrid `min()` and `max()` handle empty sets (#1481).
 
-* `n_distinct()` uses multiple arguments (#1084), falls back to R
+* `n_distinct()` uses multiple arguments for data frames (#1084), falls back to R
   evaluation when needed (#1657), reverting decision made in (#567).
+  Passing no arguments gives an error (#1957, #1959, @krlmlr).
 
 * `nth()` now supports negative indices to select from end, e.g. `nth(x, -2)`
   selects the 2nd value from the end of `x` (#1584).

--- a/inst/include/dplyr/MultipleVectorVisitors.h
+++ b/inst/include/dplyr/MultipleVectorVisitors.h
@@ -33,6 +33,9 @@ namespace dplyr {
               return visitors[k].get() ;
             }
             inline int nrows() const {
+              if( visitors.size() == 0 ){
+                stop("need at least one column for nrows()") ;
+              }
               return visitors[0]->size() ;
             }
             inline void push_back( SEXP x) {

--- a/inst/include/dplyr/visitor_set/VisitorSetHash.h
+++ b/inst/include/dplyr/visitor_set/VisitorSetHash.h
@@ -8,8 +8,11 @@ namespace dplyr{
     public:
         size_t hash( int j) const {
             const Class& obj = static_cast<const Class&>(*this) ;
-            size_t seed = obj.get(0)->hash(j) ;
             int n = obj.size() ;
+            if( n == 0 ){
+              stop("need at least one column for hash()") ;
+            }
+            size_t seed = obj.get(0)->hash(j) ;
             for( int k=1; k<n; k++){
                 boost::hash_combine( seed, obj.get(k)->hash(j) ) ;
             }

--- a/src/dplyr.cpp
+++ b/src/dplyr.cpp
@@ -159,6 +159,11 @@ Result* count_distinct_prototype(SEXP call, const LazySubsets& subsets, int narg
         return 0 ;
       }
     }
+
+    if( visitors.size() == 0 ) {
+      stop("need at least one column for n_distinct()");
+    }
+
     if( na_rm ){
       return new Count_Distinct_Narm<MultipleVectorVisitors>(visitors) ;
     } else {
@@ -1772,6 +1777,10 @@ IntegerVector group_size_grouped_cpp( GroupedDataFrame gdf ){
 
 // [[Rcpp::export]]
 SEXP n_distinct_multi( List variables, bool na_rm = false){
+    if( variables.length() == 0 ) {
+      stop("need at least one column for n_distinct()");
+    }
+
     MultipleVectorVisitors visitors(variables) ;
     SlicingIndex everything(0, visitors.nrows()) ;
     if( na_rm ){

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -461,6 +461,10 @@ test_that("n_distinct front end supports na.rm argument (#1052)", {
   expect_equal( n_distinct(x, na.rm = TRUE), 3L )
 })
 
+test_that("n_distinct without arguments stops (#1957)", {
+  expect_error( n_distinct(), "at least one column for n_distinct" )
+})
+
 test_that("hybrid evaluation does not take place for objects with a class (#1237)", {
   mean.foo <- function(x) 42
   df <- data_frame( x = structure(1:10, class = "foo" ) )
@@ -546,6 +550,11 @@ test_that("n_distinct handles multiple columns (#1084)", {
 
   res <- group_by(df, g) %>% summarise( n = n_distinct(x, y, na.rm = TRUE) )
   expect_equal( res$n, c(2L,4L) )
+})
+
+test_that("n_distinct stops if no columns are passed (#1957)", {
+  df <- data.frame( x = rep(1:4, each = 2), y = rep(1:2, each = 4), g = rep(1:2, 4))
+  expect_error(summarise( df, nd = n_distinct(), n = n()), "at least one column for n_distinct" )
 })
 
 test_that("hybrid max works when not used on columns (#1369)", {


### PR DESCRIPTION
- hash(): return index
- nrows(): stop() instead of segfault

Fixes #1957.

With tests, which pass locally. Travis fails because of tibble update (#1949).

Currently I have no idea how to make the forward of n_distinct() to n() explicit in the code for hybrid evaluation.