### PR TITLE
Fix copy_to behavior for MySQL

### DIFF
--- a/R/src-mysql.r
+++ b/R/src-mysql.r
@@ -145,7 +145,7 @@ db_has_table.MySQLConnection <- function(con, table, ...) {
 #' @export
 db_data_type.MySQLConnection <- function(con, fields, ...) {
   char_type <- function(x) {
-    n <- max(nchar(as.character(x), "bytes"))
+    n <- max(nchar(as.character(x), "bytes"), 0L, na.rm = TRUE)
     if (n <= 65535) {
       paste0("varchar(", n, ")")
     } else {

--- a/R/src-mysql.r
+++ b/R/src-mysql.r
@@ -187,11 +187,11 @@ db_insert_into.MySQLConnection <- function(con, table, values, ...) {
 
   # Encode special characters in strings
   is_char <- vapply(values, is.character, logical(1))
-  values[is_char] <- lapply(values[is_char], encodeString)
+  values[is_char] <- lapply(values[is_char], encodeString, na.encode = FALSE)
 
   tmp <- tempfile(fileext = ".csv")
   utils::write.table(values, tmp, sep = "\t", quote = FALSE, qmethod = "escape",
-    row.names = FALSE, col.names = FALSE)
+    na = "\\N", row.names = FALSE, col.names = FALSE)
 
   sql <- build_sql("LOAD DATA LOCAL INFILE ", encodeString(tmp), " INTO TABLE ",
     ident(table), con = con)


### PR DESCRIPTION
copy_to() gives an error if a character column has NAs.

Fixes #2256.