### PR TITLE
make inner joins explicit to avoid using

### DIFF
--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -183,10 +183,6 @@ sql_build.op_join <- function(op, con, ...) {
                by = by
     )
   } else {
-    # TODO: it would be better to construct an explicit FROM statement
-    # that used the table names to disambiguate the fields names: this
-    # would remove a layer of subqueries and would make sql_join more
-    # flexible.
     x <- select_(op$x, .dots = setNames(x_names, uniques$x))
     y <- select_(op$y, .dots = setNames(y_names, uniques$y))
 

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -191,7 +191,7 @@ sql_build.op_join <- function(op, con, ...) {
     x_names_no_xy[xy_by] <- NULL
     y_names_no_xy <- as.list(uniques$y)
     y_names_no_xy[xy_by] <- NULL
-    xy_names <- c(x_names_no_xy, y_names_no_xy, uniques$x[xy_by])
+    xy_names <- c(unname(x_names_no_xy), unname(y_names_no_xy), uniques$x[xy_by])
 
     by$x <- unname(uniques$x[by$x])
     by$y <- unname(uniques$y[by$y])
@@ -201,11 +201,7 @@ sql_build.op_join <- function(op, con, ...) {
                  type = op$args$type,
                  by = by
       ),
-      select = ident(unlist(c(
-        unname(x_names_no_xy),
-        unname(y_names_no_xy),
-        uniques$x[xy_by]
-      )))
+      select = ident(unlist(xy_names))
     )
   }
 }

--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -102,15 +102,9 @@ sql_join.default <- function(con, x, y, type = "inner", by = NULL, ...) {
     stop("Unknown join type:", type, call. = FALSE)
   )
 
-  using <- all(by$x == by$y)
-
-  if (using) {
-    cond <- build_sql("USING ", lapply(by$x, ident), con = con)
-  } else {
-    on <- sql_vector(paste0(sql_escape_ident(con, by$x), " = ", sql_escape_ident(con, by$y)),
-      collapse = " AND ", parens = TRUE)
-    cond <- build_sql("ON ", on, con = con)
-  }
+  on <- sql_vector(paste0(sql_escape_ident(con, by$x), " = ", sql_escape_ident(con, by$y)),
+    collapse = " AND ", parens = TRUE)
+  cond <- build_sql("ON ", on, con = con)
 
   build_sql(
     'SELECT * FROM ',x, "\n\n",

--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -106,6 +106,7 @@ sql_join.default <- function(con, x, y, type = "inner", by = NULL, ...) {
     collapse = " AND ", parens = TRUE)
   cond <- build_sql("ON ", on, con = con)
 
+  # Wrap with SELECT since callers assume a valid query is returned
   build_sql(
     'SELECT * FROM ',x, "\n\n",
     join, " JOIN\n\n" ,

--- a/tests/testthat/test-sql-build.R
+++ b/tests/testthat/test-sql-build.R
@@ -158,9 +158,9 @@ test_that("join captures both tables", {
 
   out <- inner_join(lf1, lf2) %>% sql_build()
 
-  expect_equal(op_vars(out$x), c("x", "y"))
-  expect_equal(op_vars(out$y), c("x", "z"))
-  expect_equal(out$type, "inner")
+  expect_equal(op_vars(out$from$x), c("x.x", "y"))
+  expect_equal(op_vars(out$from$y), c("x.y", "z"))
+  expect_equal(out$from$type, "inner")
 })
 
 test_that("semi join captures both tables", {

--- a/tests/testthat/test-sql-joins.R
+++ b/tests/testthat/test-sql-joins.R
@@ -3,6 +3,8 @@ context("SQL: joins")
 src <- src_sqlite(tempfile(), create = TRUE)
 df1 <- copy_to(src, data.frame(x = 1:5, y = 1:5), "df1")
 df2 <- copy_to(src, data.frame(a = 5:1, b = 1:5), "df2")
+df3 <- copy_to(src, data.frame(x = 1:5, z = 1:5), "df3")
+df4 <- copy_to(src, data.frame(a = 5:1, z = 5:1), "df4")
 fam <- copy_to(src, data.frame(id = 1:5, parent = c(NA, 1, 2, 2, 4)), "fam")
 
 test_that("named by join by different x and y vars", {
@@ -15,6 +17,13 @@ test_that("named by join by different x and y vars", {
   j2 <- collect(inner_join(df1, df2, c("x" = "a", "y" = "b")))
   expect_equal(names(j2), c("x", "y", "a", "b"))
   expect_equal(nrow(j2), 1)
+})
+
+test_that("named by join by same z vars", {
+  skip_if_no_sqlite()
+
+  j1 <- collect(inner_join(df3, df4, c("z" = "z")))
+  expect_equal(nrow(j1), 5)
 })
 
 test_that("inner join doesn't result in duplicated columns ", {


### PR DESCRIPTION
@hadley Spark and SQL Server have issues with the `USING` statement and natural joins respectively. This change removes the use of `USING` by making joins explicit at all times. Feedback welcomed. Example follows:

```
library(dplyr)
src <- src_sqlite(tempfile(), create = TRUE)
data_frame(a = 1:3, b = letters[1:3]) %>% copy_to(src, ., "df1")
data_frame(b = letters[1:3], c = letters[24:26]) %>% copy_to(src, ., "df2")
```

Without this PR: `left_join(tbl(src, "df1"), tbl(src, "df2"))`:

```
<SQL> SELECT * FROM 'df1'

LEFT JOIN

'df2'

USING ('b')
```

with this PR: `left_join(tbl(src, "df1"), tbl(src, "df2"))`:

```
SELECT 'a', 'c', 'b.x' AS 'b'
FROM (
   SELECT * FROM 
      (SELECT 'a' AS 'a', 'b' AS 'b.x' FROM 'df1')
   LEFT JOIN
      (SELECT 'b' AS 'b.y', 'c' AS 'c' FROM 'df2')
   ON ('b.x' = 'b.y')
)
```
