### PR TITLE
case_when support of NA values

### DIFF
--- a/R/case_when.R
+++ b/R/case_when.R
@@ -53,6 +53,7 @@ case_when <- function(...) {
     env <- environment(f)
 
     query[[i]] <- eval(f[[2]], envir = env)
+    query[[i]][is.na(query[[i]])] <- FALSE
     if (!is.logical(query[[i]])) {
       stop("LHS of case ", i, " (", deparse_trunc(f_lhs(f)),
            ") is ", typeof(query[[i]]), ", not logical",

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -53,7 +53,6 @@ case_when <- function(...) {
     env <- environment(f)
 
     query[[i]] <- eval(f[[2]], envir = env)
-    query[[i]][is.na(query[[i]])] <- FALSE
     if (!is.logical(query[[i]])) {
       stop("LHS of case ", i, " (", deparse_trunc(f_lhs(f)),
            ") is ", typeof(query[[i]]), ", not logical",
@@ -75,7 +74,7 @@ case_when <- function(...) {
     out <- replace_with(
       out, query[[i]] & !replaced, value[[i]],
       paste0("RHS of case ", i, " (", deparse_trunc(f_rhs(formulas[[i]])), ")"))
-    replaced <- replaced | query[[i]]
+    replaced <- replaced | (query[[i]] & !is.na(query[[i]]))
   }
 
   out

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -64,3 +64,15 @@ test_that("unmatched gets missing value", {
     c(1, 2, NA)
   )
 })
+
+test_that("missing values can be replaced (#1999)", {
+  x <- c(1:3, NA)
+  expect_equal(
+    case_when(
+      x <= 1 ~ 1,
+      x <= 2 ~ 2,
+      is.na(x) ~ 0
+    ),
+    c(1, 2, NA, 0)
+  )
+})


### PR DESCRIPTION
#1999. `case_when` stores results of formula evaluations as vectors in `query`. These values are used to determine which elements in the input vector need to be overwritten. But an NA in an earlier query result would infect TRUE values in other queries. Therefore, I've updated the function to treat NAs as FALSE (when it comes to determining which values need to be replaced).

Also, added a unit test.