### PR TITLE
bind_cols() handles empty argument list

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -176,6 +176,8 @@ List rbind_list__impl( Dots dots ){
 template <typename Dots>
 List cbind__impl( Dots dots ){
   int n = dots.size() ;
+  if ( n == 0 )
+    return DataFrame();
 
   DataFrameAbleVector chunks ;
   for( int i=0; i<n; i++) {

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -29,6 +29,10 @@ test_that("bind_cols handles lists (#1104)", {
   expect_equal(bind_cols(list(l1, l2)), exp)
 })
 
+test_that("bind_cols handles empty argument list (#1963)", {
+  expect_equal(bind_cols(), data.frame())
+})
+
 # rows --------------------------------------------------------------------
 
 df_var <- data_frame(


### PR DESCRIPTION
With test.

Fixes #1963.