### PR TITLE
Fix the problem that group_by() cannot handle UTF-8 column names on Windows

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -46,7 +46,14 @@ add_rownames <- function(df, var = "rowname") {
 #' @export
 group_by_.data.frame <- function(.data, ..., .dots, add = FALSE) {
   groups <- group_by_prepare(.data, ..., .dots = .dots, add = add)
-  grouped_df(groups$data, groups$groups)
+  
+  names.orig <- names(groups$data)
+  names(groups$data) <- enc2native(names(groups$data))
+  
+  ret <- grouped_df(groups$data, groups$groups)
+  
+  names(ret) <- names.orig
+  ret
 }
 
 #' @export


### PR DESCRIPTION
Hi, this is just a workaround to the issue #2005 (and  possibly related to #1555). With this fix the following example works properly:

```
library(dplyr)
data(iris)
iris %>%
    mutate(品種 = Species) %>%
    group_by(品種) %>%
    summarise(avg = mean(Sepal.Length))
```

It would be preferable to fix build_index_cpp to handle multiple encodings, however this workaround is simple and works as expected.
