### PR TITLE
add dplyr.tibble.print to override tibble printing behavior

### DIFF
--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -29,7 +29,7 @@ print.grouped_df <- function(x, ..., n = NULL, width = NULL) {
   grps <- if (is.null(attr(x, "indices"))) "?" else length(attr(x, "indices"))
   cat("Groups: ", commas(deparse_all(groups(x))), " [", big_mark(grps), "]\n", sep = "")
   cat("\n")
-  print(trunc_mat(x, n = n, width = width), ...)
+  trunc_mat_print(x, n = n, width = width, ...)
   invisible(x)
 }
 

--- a/R/rowwise.r
+++ b/R/rowwise.r
@@ -28,7 +28,7 @@ print.rowwise_df <- function(x, ..., n = NULL, width = NULL) {
   cat("Source: local data frame ", dim_desc(x), "\n", sep = "")
   cat("Groups: <by row>\n")
   cat("\n")
-  print(trunc_mat(x, n = n, width = width))
+  trunc_mat_print(x, n = n, width = width)
   invisible(x)
 }
 

--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -68,7 +68,8 @@ print.tbl_sql <- function(x, ..., n = NULL, width = NULL) {
 
   cat("\n")
 
-  print(trunc_mat(x, n = n, width = width))
+  trunc_mat_print(x, n = n, width = width)
+
   invisible(x)
 }
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -172,3 +172,10 @@ is_1d <- function(x) {
 }
 
 is_bare_list <- function(x) is.list(x) && !is.object(x)
+
+trunc_mat_print <- function(x, n, width, ...) {
+  tibblePrint <- getOption("dplyr.tibble.print", function(x, n = n, width = width, ...) {
+    print(trunc_mat(x, n = n, width = width, ...))
+  })
+  tibblePrint(x, n = n, width = width, ...)
+}


### PR DESCRIPTION
This PR adds a `dplyr.tibble.print` option to allow users to override tibble printing behavior.

<img width="918" alt="screen shot 2016-08-09 at 4 03 43 pm" src="https://cloud.githubusercontent.com/assets/3478847/17536597/e7d3c2f0-5e4a-11e6-9bab-e8f773cf225e.png">
