### PR TITLE
fixes select_if with non standard names, #2044 and #1978

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -304,6 +304,7 @@ select_if <- function(.data, .predicate, ...) {
       call. = FALSE)
   }
   vars <- probe_colwise_names(.data, .predicate, ...)
+  vars <- sprintf('`%s`', vars)
   vars <- ensure_grouped_vars(vars, .data, notify = FALSE)
   select_(.data, .dots = vars)
 }

--- a/tests/testthat/test-select.r
+++ b/tests/testthat/test-select.r
@@ -183,3 +183,8 @@ test_that("select_if handles non standard names", {
   expect_identical(tibble(`1foo` = 1L) %>% select_if(is.integer),
                    tibble(`1foo` = 1L) %>% select(`1foo`))
 })
+
+test_that("select_if fails for non standard names with ticks", {
+  expect_error(tibble(`\`foo` = 1L) %>% select_if(is.integer))
+  expect_identical(tibble(`\`foo` = 1L) %>% select(`\`foo`), tibble(`\`foo` = 1L))
+})

--- a/tests/testthat/test-select.r
+++ b/tests/testthat/test-select.r
@@ -178,3 +178,8 @@ test_that("select_if keeps grouping cols", {
   expect_silent(df <- iris %>% group_by(Species) %>% select_if(is.numeric))
   expect_equal(df, tbl_df(iris[c(5, 1:4)]))
 })
+
+test_that("select_if handles non standard names", {
+  expect_identical(tibble(`1foo` = 1L) %>% select_if(is.integer),
+                   tibble(`1foo` = 1L) %>% select(`1foo`))
+})


### PR DESCRIPTION
Small hack. Maybe it would be better to fix `select_`.
