### PR TITLE
FIX: column reference "col_name" is ambiguous when joining in Postgresql

### DIFF
--- a/R/join.r
+++ b/R/join.r
@@ -138,13 +138,12 @@ unique_names <- function(x_names, y_names, by, suffix = c(".x", ".y")) {
 
   suffix <- check_suffix(suffix)
 
-  x_match <- match(common, x_names)
+  # Force rename all to avoid ambiguity
   x_new <- x_names
-  x_new[x_match] <- paste0(x_names[x_match], suffix$x)
+  x_new<- paste0(x_names, suffix$x)
 
-  y_match <- match(common, y_names)
   y_new <- y_names
-  y_new[y_match] <- paste0(y_names[y_match], suffix$y)
+  y_new <- paste0(y_names, suffix$y)
 
   list(x = setNames(x_new, x_names), y = setNames(y_new, y_names))
 }


### PR DESCRIPTION
When both different and identical names existed in 'by', ambiguity arise.

i.e. `left_join(table_a, table_b , by = c("col_name"="col_name","col_a"="col_b")`

Suggested to force rename all.
