### PR TITLE
SQL like wildcard is % not *

### DIFF
--- a/R/translate-sql.r
+++ b/R/translate-sql.r
@@ -58,7 +58,7 @@
 #' translate_sql(if (x > 5) "big" else "small")
 #'
 #' # Infix functions are passed onto SQL with % removed
-#' translate_sql(first %like% "Had%")
+#' translate_sql(first %like% "Had\%")
 #' translate_sql(first %is% NULL)
 #' translate_sql(first %in% c("John", "Roger", "Robert"))
 #'

--- a/R/translate-sql.r
+++ b/R/translate-sql.r
@@ -58,7 +58,7 @@
 #' translate_sql(if (x > 5) "big" else "small")
 #'
 #' # Infix functions are passed onto SQL with % removed
-#' translate_sql(first %like% "Had*")
+#' translate_sql(first %like% "Had%")
 #' translate_sql(first %is% NULL)
 #' translate_sql(first %in% c("John", "Roger", "Robert"))
 #'

--- a/R/translate-sql.r
+++ b/R/translate-sql.r
@@ -58,7 +58,7 @@
 #' translate_sql(if (x > 5) "big" else "small")
 #'
 #' # Infix functions are passed onto SQL with % removed
-#' translate_sql(first %like% "Had\%")
+#' translate_sql(first %like% "Had%")
 #' translate_sql(first %is% NULL)
 #' translate_sql(first %in% c("John", "Roger", "Robert"))
 #'

--- a/man/translate_sql.Rd
+++ b/man/translate_sql.Rd
@@ -80,7 +80,7 @@ translate_sql(xor(x, y))
 translate_sql(if (x > 5) "big" else "small")
 
 # Infix functions are passed onto SQL with \% removed
-translate_sql(first \%like\% "Had%")
+translate_sql(first \%like\% "Had*")
 translate_sql(first \%is\% NULL)
 translate_sql(first \%in\% c("John", "Roger", "Robert"))
 

--- a/man/translate_sql.Rd
+++ b/man/translate_sql.Rd
@@ -80,7 +80,7 @@ translate_sql(xor(x, y))
 translate_sql(if (x > 5) "big" else "small")
 
 # Infix functions are passed onto SQL with \% removed
-translate_sql(first \%like\% "Had*")
+translate_sql(first \%like\% "Had%")
 translate_sql(first \%is\% NULL)
 translate_sql(first \%in\% c("John", "Roger", "Robert"))
 

--- a/vignettes/databases.Rmd
+++ b/vignettes/databases.Rmd
@@ -182,7 +182,7 @@ Any function that dplyr doesn't know how to convert is left as is. This means th
 
 ```{r}
 translate_sql(glob(x, y))
-translate_sql(x %like% "ab*")
+translate_sql(x %like% "ab%")
 ```
 
 ## Grouping


### PR DESCRIPTION
```
library(RSQLite)
library(nycflights13)
dat <- nycflights13_sqlite() %>% tbl("flights")
dat %>% filter(dest %like% "IA*") %>% tally() # returns 0 rows
dat %>% filter(dest %like% "IA%") %>% group_by(dest) %>% tally() 
# dest     n
# <chr> <int>
# 1   IAD  5700
# 2   IAH  7198
```