### PR TITLE
Allow unnamed additional arguments in colwise verbs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@
 * Fix issue with `mutate_if()` and `summarise_if()` when a predicate
   function returns a vector of `FALSE` (#1989, #2009).
 
+* `mutate_all()` etc now accept unnamed additional arguments.
+
 # dplyr 0.5.0
 
 ## Breaking changes

--- a/R/funs.R
+++ b/R/funs.R
@@ -131,13 +131,10 @@ merge_args <- function(call, args) {
   if (!length(args)) {
     return(call)
   }
-  if (is.null(names(args))) {
-    stop("Additional arguments should be named", call. = FALSE)
-  }
 
-  for (param in names(args)) {
-    call[[param]] <- args[[param]]
-  }
+  index <- seq(length(call) + 1, length(call) + length(args))
+  call[index] <- args
+  names(call)[index] <- names2(args)
 
   call
 }


### PR DESCRIPTION
So that we can do:

```r
df %>% mutate_all(round, 2)
```

Found a weird R inconsistency while writing this:

```r
c <- call("fun", quote(arg))
names(c)[2] <- "n"
names(c)
#> [1] ""  "n"

l <- list(1, 2)
names(l)[2] <- "n"
names(l)
#> [1] NA  "n"
```

also

```r
names(c) <- c(NA, NA)
names(c)
#> NULL

names(l) <- c(NA, NA)
names(l)
#> [1] NA NA
```