### PR TITLE
use dbFetch() instead of fetch()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     tibble,
     magrittr,
     lazyeval (>= 0.1.10),
-    DBI (>= 0.4.1)
+    DBI (>= 0.5)
 Suggests: 
     RSQLite (>= 1.0.0),
     RMySQL,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.5.0.9000
 
+* Now calling `dbFetch()` instead of the deprecated `fetch()` (#2134).
+
 * Using larger hash tables gives slightly better performance for `n_distinct()` and ordering of character vectors (#977).
 
 * Fix typo in C++ registration code (which is most likely unused at the moment).

--- a/R/query.r
+++ b/R/query.r
@@ -41,7 +41,7 @@ Query <- R6::R6Class("Query",
       res <- dbSendQuery(self$con, self$sql)
       on.exit(dbClearResult(res))
 
-      out <- fetch(res, n)
+      out <- dbFetch(res, n)
       res_warn_incomplete(res)
       out
     },
@@ -51,7 +51,7 @@ Query <- R6::R6Class("Query",
       on.exit(dbClearResult(qry))
 
       while (!dbHasCompleted(qry)) {
-        chunk <- fetch(qry, chunk_size)
+        chunk <- dbFetch(qry, chunk_size)
         callback(chunk)
       }
 


### PR DESCRIPTION
to avoid deprecation warnings