### PR TITLE
allow `n_distinct()` to accept `...` arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.5.0.9000
 
+* The SQL aggregate function `n_distinct()` now accepts `...`.
+
 * Add tests for grouping behaviour (#833, #2085, @bpbond).
 
 * Refactor `common_by()` (#1928).

--- a/R/translate-sql-base.r
+++ b/R/translate-sql-base.r
@@ -141,9 +141,7 @@ base_agg <- sql_translator(
   sum        = sql_prefix("sum", 1),
   min        = sql_prefix("min", 1),
   max        = sql_prefix("max", 1),
-  n_distinct = function(x) {
-    build_sql("COUNT(DISTINCT ", x, ")")
-  }
+  n_distinct = function(...) build_sql("COUNT(DISTINCT", list(...), ")")
 )
 
 #' @export


### PR DESCRIPTION
This allows `n_distinct()` to be more permissive, for SQL engines which accept one or more columns to `count(DISTINCT ....)`.
