### PR TITLE
New RowwiseSlicingIndex, NaturalSlicingIndex and OffsetSlicingIndex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.5.0.9000
 
+* `SlicingIndex` is now a virtual class with specialized implementations `GroupedSlicingIndex`, `RowwiseSlicingIndex`, `NaturalSlicingIndex` and `OffsetSlicingIndex` (#2187).
+
 * CallProxy is now a specialization of GroupedCallProxy.
 
 * Fix conversion of character `NA` to empty strings in a grouped `summarise()` (#1839).

--- a/inst/include/dplyr/FullDataFrame.h
+++ b/inst/include/dplyr/FullDataFrame.h
@@ -5,7 +5,7 @@ namespace dplyr {
 
   class FullDataFrame {
   public:
-    FullDataFrame(const DataFrame& data_) : index(0, data_.nrows()) {}
+    FullDataFrame(const DataFrame& data_) : index(data_.nrows()) {}
 
     const SlicingIndex& get_index() const {
       return index;
@@ -16,7 +16,7 @@ namespace dplyr {
     }
 
   private:
-    SlicingIndex index;
+    NaturalSlicingIndex index;
   };
 
 }

--- a/inst/include/dplyr/FullDataFrame.h
+++ b/inst/include/dplyr/FullDataFrame.h
@@ -5,7 +5,7 @@ namespace dplyr {
 
   class FullDataFrame {
   public:
-    typedef NaturalSlicingIndex SlicingIndex;
+    typedef NaturalSlicingIndex slicing_index;
 
     FullDataFrame(const DataFrame& data_) : index(data_.nrows()) {}
 

--- a/inst/include/dplyr/FullDataFrame.h
+++ b/inst/include/dplyr/FullDataFrame.h
@@ -5,6 +5,8 @@ namespace dplyr {
 
   class FullDataFrame {
   public:
+    typedef NaturalSlicingIndex SlicingIndex;
+
     FullDataFrame(const DataFrame& data_) : index(data_.nrows()) {}
 
     const SlicingIndex& get_index() const {

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -42,7 +42,7 @@ namespace dplyr {
       ++git;
       i++;
       for (; i<ngroups; i++, ++git) {
-        SlicingIndex indices = *git;
+        const SlicingIndex& indices = *git;
         Shield<SEXP> subset(proxy.get(indices));
         grab(subset, indices);
       }
@@ -122,7 +122,7 @@ namespace dplyr {
       ++git;
       i++;
       for (; i<ngroups; i++, ++git) {
-        SlicingIndex indices = *git;
+        const SlicingIndex& indices = *git;
         List subset(proxy.get(indices));
         perhaps_duplicate(subset);
         grab(subset, indices);
@@ -200,7 +200,7 @@ namespace dplyr {
       int i = 0;
       for (; i<first_non_na; i++) ++git;
       for (; i<ngroups; i++, ++git) {
-        SlicingIndex indices = *git;
+        const SlicingIndex& indices = *git;
         Factor subset(proxy.get(indices));
         grab(subset, indices);
       }
@@ -304,7 +304,7 @@ namespace dplyr {
   template <typename Data, typename Subsets>
   inline Gatherer* gatherer(GroupedCallProxy<Data,Subsets>& proxy, const Data& gdf, SEXP name) {
     typename Data::group_iterator git = gdf.group_begin();
-    SlicingIndex indices = *git;
+    FullSlicingIndex indices = *git;
     RObject first(proxy.get(indices));
 
     if (Rf_inherits(first, "POSIXlt")) {

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -304,7 +304,7 @@ namespace dplyr {
   template <typename Data, typename Subsets>
   inline Gatherer* gatherer(GroupedCallProxy<Data,Subsets>& proxy, const Data& gdf, SEXP name) {
     typename Data::group_iterator git = gdf.group_begin();
-    GroupedSlicingIndex indices = *git;
+    typename Data::SlicingIndex indices = *git;
     RObject first(proxy.get(indices));
 
     if (Rf_inherits(first, "POSIXlt")) {

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -304,7 +304,7 @@ namespace dplyr {
   template <typename Data, typename Subsets>
   inline Gatherer* gatherer(GroupedCallProxy<Data,Subsets>& proxy, const Data& gdf, SEXP name) {
     typename Data::group_iterator git = gdf.group_begin();
-    FullSlicingIndex indices = *git;
+    GroupedSlicingIndex indices = *git;
     RObject first(proxy.get(indices));
 
     if (Rf_inherits(first, "POSIXlt")) {

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -304,7 +304,7 @@ namespace dplyr {
   template <typename Data, typename Subsets>
   inline Gatherer* gatherer(GroupedCallProxy<Data,Subsets>& proxy, const Data& gdf, SEXP name) {
     typename Data::group_iterator git = gdf.group_begin();
-    typename Data::SlicingIndex indices = *git;
+    typename Data::slicing_index indices = *git;
     RObject first(proxy.get(indices));
 
     if (Rf_inherits(first, "POSIXlt")) {

--- a/inst/include/dplyr/GroupedDataFrame.h
+++ b/inst/include/dplyr/GroupedDataFrame.h
@@ -37,7 +37,7 @@ namespace dplyr {
 
     GroupedDataFrameIndexIterator& operator++();
 
-    FullSlicingIndex operator*() const;
+    GroupedSlicingIndex operator*() const;
 
     int i;
     const GroupedDataFrame& gdf;
@@ -139,8 +139,8 @@ namespace dplyr {
     return *this;
   }
 
-  inline FullSlicingIndex GroupedDataFrameIndexIterator::operator*() const {
-    return FullSlicingIndex(IntegerVector(indices[i]), i);
+  inline GroupedSlicingIndex GroupedDataFrameIndexIterator::operator*() const {
+    return GroupedSlicingIndex(IntegerVector(indices[i]), i);
   }
 
 }

--- a/inst/include/dplyr/GroupedDataFrame.h
+++ b/inst/include/dplyr/GroupedDataFrame.h
@@ -37,7 +37,7 @@ namespace dplyr {
 
     GroupedDataFrameIndexIterator& operator++();
 
-    SlicingIndex operator*() const;
+    FullSlicingIndex operator*() const;
 
     int i;
     const GroupedDataFrame& gdf;
@@ -139,8 +139,8 @@ namespace dplyr {
     return *this;
   }
 
-  inline SlicingIndex GroupedDataFrameIndexIterator::operator*() const {
-    return SlicingIndex(IntegerVector(indices[i]), i);
+  inline FullSlicingIndex GroupedDataFrameIndexIterator::operator*() const {
+    return FullSlicingIndex(IntegerVector(indices[i]), i);
   }
 
 }

--- a/inst/include/dplyr/GroupedDataFrame.h
+++ b/inst/include/dplyr/GroupedDataFrame.h
@@ -47,7 +47,7 @@ namespace dplyr {
   class GroupedDataFrame {
   public:
     typedef GroupedDataFrameIndexIterator group_iterator;
-    typedef GroupedSlicingIndex SlicingIndex;
+    typedef GroupedSlicingIndex slicing_index;
 
     GroupedDataFrame(SEXP x):
       data_(x),

--- a/inst/include/dplyr/GroupedDataFrame.h
+++ b/inst/include/dplyr/GroupedDataFrame.h
@@ -47,6 +47,8 @@ namespace dplyr {
   class GroupedDataFrame {
   public:
     typedef GroupedDataFrameIndexIterator group_iterator;
+    typedef GroupedSlicingIndex SlicingIndex;
+
     GroupedDataFrame(SEXP x):
       data_(x),
       group_sizes(),

--- a/inst/include/dplyr/Hybrid.h
+++ b/inst/include/dplyr/Hybrid.h
@@ -9,6 +9,4 @@ namespace dplyr {
 
 }
 
-bool can_simplify(SEXP);
-
 #endif // dplyr_dplyr_Hybrid_H

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -77,19 +77,24 @@ namespace dplyr {
         LOG_VERBOSE << "setting " << n << " proxies";
         for (int i=0; i<n; i++) {
           LOG_VERBOSE << "setting proxy " << CHAR(PRINTNAME(proxies[i].symbol));
-          proxies[i].set(subsets.get(proxies[i].symbol, indices));
+          proxies[i].set(get_subset(subsets, proxies[i].symbol, indices));
         }
 
         return call.eval(env);
       } else if (TYPEOF(call) == SYMSXP) {
         if (subsets.count(call)) {
-          return subsets.get(call, indices);
+          return get_subset(subsets, call, indices);
         }
         return env.find(CHAR(PRINTNAME(call)));
       } else {
         // all other types that evaluate to themselves
         return call;
       }
+    }
+
+    template <class Subsets_>
+    static SEXP get_subset(Subsets_& subsets, SEXP call, const SlicingIndex& indices) {
+      subsets.get(call, indices);
     }
 
     void set_call(SEXP call_) {

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -98,45 +98,6 @@ namespace dplyr {
     }
 
   private:
-    bool simplified(const SlicingIndex& indices) {
-      // initial
-      if (TYPEOF(call) == LANGSXP) {
-        boost::scoped_ptr<Result> res(get_handler(call, subsets, env));
-
-        if (res) {
-          // replace the call by the result of process
-          call = res->process(indices);
-
-          // no need to go any further, we simplified the top level
-          return true;
-        }
-
-        return replace(CDR(call), indices);
-
-      }
-      return false;
-    }
-
-    bool replace(SEXP p, const SlicingIndex& indices) {
-      SEXP obj = CAR(p);
-
-      if (TYPEOF(obj) == LANGSXP) {
-        boost::scoped_ptr<Result> res(get_handler(obj, subsets, env));
-        if (res) {
-          SETCAR(p, res->process(indices));
-          return true;
-        }
-
-        if (replace(CDR(obj), indices)) return true;
-      }
-
-      if (TYPEOF(p) == LISTSXP) {
-        return replace(CDR(p), indices);
-      }
-
-      return false;
-    }
-
     void traverse_call(SEXP obj) {
       if (TYPEOF(obj) == LANGSXP && CAR(obj) == Rf_install("local")) return;
 

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -49,7 +49,7 @@ namespace dplyr {
         return hybrid_eval.eval();
       } else if (TYPEOF(call) == SYMSXP) {
         if (subsets.count(call)) {
-          return detail::get_proxy_subset(subsets, call, indices);
+          return subsets.get(call, indices);
         }
         return env.find(CHAR(PRINTNAME(call)));
       } else {

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -44,21 +44,9 @@ namespace dplyr {
       subsets.clear();
 
       if (TYPEOF(call) == LANGSXP) {
-        if (can_simplify(call)) {
-          LOG_VERBOSE << "performing hybrid evaluation";
-          HybridCall hybrid_eval(call, indices, subsets, env);
-          return hybrid_eval.eval();
-        }
-
-        int n = proxies.size();
-
-        LOG_VERBOSE << "setting " << n << " proxies";
-        for (int i=0; i<n; i++) {
-          LOG_VERBOSE << "setting proxy " << CHAR(PRINTNAME(proxies[i].symbol));
-          proxies[i].set(detail::get_proxy_subset(subsets, proxies[i].symbol, indices));
-        }
-
-        return call.eval(env);
+        LOG_VERBOSE << "performing hybrid evaluation";
+        HybridCall hybrid_eval(call, indices, subsets, env);
+        return hybrid_eval.eval();
       } else if (TYPEOF(call) == SYMSXP) {
         if (subsets.count(call)) {
           return detail::get_proxy_subset(subsets, call, indices);

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -60,8 +60,7 @@ namespace dplyr {
 
     // Only for ungrouped CallProxy, always use full slicing index; see detail::get_proxy_subset()
     SEXP eval() {
-      SlicingIndex indices(0, subsets.nrows());
-      return get(indices);
+      return get(NaturalSlicingIndex(subsets.nrows()));
     }
 
     void set_call(SEXP call_) {

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -39,26 +39,8 @@ namespace dplyr {
     ~GroupedCallProxy() {}
 
     SEXP eval() {
-      if (TYPEOF(call) == LANGSXP) {
-
-        if (can_simplify(call)) {
-          SlicingIndex indices(0,subsets.nrows());
-          while (simplified(indices))
-            ;
-          set_call(call);
-        }
-
-        int n = proxies.size();
-        for (int i=0; i<n; i++) {
-          proxies[i].set(subsets[proxies[i].symbol]);
-        }
-        return call.eval(env);
-      } else if (TYPEOF(call) == SYMSXP) {
-        // SYMSXP
-        if (subsets.count(call)) return subsets.get_variable(call);
-        return call.eval(env);
-      }
-      return call;
+      SlicingIndex indices(0, subsets.nrows());
+      return get(indices);
     }
 
     template <typename Container>

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -39,8 +39,7 @@ namespace dplyr {
 
     ~GroupedCallProxy() {}
 
-    template <typename Container>
-    SEXP get(const Container& indices) {
+    SEXP get(const SlicingIndex& indices) {
       subsets.clear();
 
       if (TYPEOF(call) == LANGSXP) {

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -57,7 +57,6 @@ namespace dplyr {
       }
     }
 
-    // Only for ungrouped CallProxy, always use full slicing index; see detail::get_proxy_subset()
     SEXP eval() {
       return get(NaturalSlicingIndex(subsets.nrows()));
     }

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -14,12 +14,6 @@ namespace dplyr {
     inline SEXP get_proxy_subset(Subsets& subsets, SEXP call, const SlicingIndex& indices) {
       return subsets.get(call, indices);
     }
-
-    // Only for ungrouped CallProxy, always use full slicing index; see GroupedCallProxy::eval()
-    template <>
-    inline SEXP get_proxy_subset(LazySubsets& subsets, SEXP call, const SlicingIndex&) {
-      return subsets[call];
-    }
   }
 
   template <typename Subsets>

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -9,13 +9,6 @@
 
 namespace dplyr {
 
-  namespace detail {
-    template <class Subsets>
-    inline SEXP get_proxy_subset(Subsets& subsets, SEXP call, const SlicingIndex& indices) {
-      return subsets.get(call, indices);
-    }
-  }
-
   template <typename Subsets>
   class GroupedHybridCall {
   public:
@@ -31,7 +24,7 @@ namespace dplyr {
         return Rcpp_eval(call, env);
       } else if (TYPEOF(call) == SYMSXP) {
         if (subsets.count(call)) {
-          return detail::get_proxy_subset(subsets, call, indices);
+          return subsets.get(call, indices);
         }
         return env.find(CHAR(PRINTNAME(call)));
       }
@@ -71,7 +64,7 @@ namespace dplyr {
         case SYMSXP:
           if (TYPEOF(obj) != LANGSXP) {
             if (subsets.count(head)) {
-              SETCAR(obj, detail::get_proxy_subset(subsets, head, indices));
+              SETCAR(obj, subsets.get(head, indices));
             }
           }
           break;

--- a/inst/include/dplyr/Result/Lag.h
+++ b/inst/include/dplyr/Result/Lag.h
@@ -50,7 +50,7 @@ namespace dplyr {
     virtual SEXP process(const FullDataFrame& df) {
       int nrows = df.nrows();
       Vector<RTYPE> out = no_init(nrows);
-      SlicingIndex index = df.get_index();
+      const SlicingIndex& index = df.get_index();
       process_slice(out, index, index);
       copy_most_attributes(out, data);
       return out;
@@ -59,7 +59,7 @@ namespace dplyr {
     virtual SEXP process(const SlicingIndex& index) {
       int nrows = index.size();
       Vector<RTYPE> out = no_init(nrows);
-      SlicingIndex fake(0, nrows);
+      NaturalSlicingIndex fake(nrows);
       process_slice(out, index, fake);
       copy_most_attributes(out, data);
       return out;

--- a/inst/include/dplyr/Result/LazyGroupedSubsets.h
+++ b/inst/include/dplyr/Result/LazyGroupedSubsets.h
@@ -26,6 +26,7 @@ namespace dplyr {
       const DataFrame& data = gdf.data();
       CharacterVector names = data.names();
       int n = data.size();
+      LOG_VERBOSE << "processing " << n << " vars: " << names;
       for (int i=0; i<n; i++) {
         input_subset(names[i], grouped_subset(data[i], max_size));
       }

--- a/inst/include/dplyr/Result/LazySubsets.h
+++ b/inst/include/dplyr/Result/LazySubsets.h
@@ -27,6 +27,8 @@ namespace dplyr {
     }
     virtual ~LazySubsets() {}
 
+    void clear() {}
+
     virtual SEXP get_variable(SEXP symbol) const {
       return data[ symbol_map.get(symbol) ];
     }

--- a/inst/include/dplyr/Result/LazySubsets.h
+++ b/inst/include/dplyr/Result/LazySubsets.h
@@ -2,6 +2,7 @@
 #define dplyr_LazySubsets_H
 
 #include <tools/SymbolMap.h>
+#include <tools/SlicingIndex.h>
 
 namespace dplyr {
 
@@ -59,6 +60,15 @@ namespace dplyr {
 
     inline SEXP& operator[](SEXP symbol) {
       return data[symbol_map.get(symbol)];
+    }
+
+    inline SEXP get(SEXP symbol, const SlicingIndex& indices) {
+      const int pos = symbol_map.get(symbol);
+      SEXP col = data[pos];
+      if (!indices.is_identity(col) && Rf_length(col) != 1)
+        stop("Attempt to query lazy column with non-natural slicing index");
+
+      return col;
     }
   };
 

--- a/inst/include/dplyr/Result/Lead.h
+++ b/inst/include/dplyr/Result/Lead.h
@@ -52,7 +52,7 @@ namespace dplyr {
     virtual SEXP process(const FullDataFrame& df) {
       int nrows = df.nrows();
       Vector<RTYPE> out = no_init(nrows);
-      SlicingIndex index = df.get_index();
+      const SlicingIndex& index = df.get_index();
       process_slice(out, index, index);
       copy_most_attributes(out, data);
       return out;
@@ -61,7 +61,7 @@ namespace dplyr {
     virtual SEXP process(const SlicingIndex& index) {
       int nrows = index.size();
       Vector<RTYPE> out = no_init(nrows);
-      SlicingIndex fake(0, nrows);
+      NaturalSlicingIndex fake(nrows);
       process_slice(out, index, fake);
       copy_most_attributes(out, data);
       return out;

--- a/inst/include/dplyr/Result/Mutater.h
+++ b/inst/include/dplyr/Result/Mutater.h
@@ -33,7 +33,7 @@ namespace dplyr {
 
     virtual SEXP process(const FullDataFrame& df) {
       Vector<RTYPE> out = no_init(df.nrows());
-      SlicingIndex index = df.get_index();
+      const SlicingIndex& index = df.get_index();
       static_cast<Derived&>(*this).process_slice(out, index, index);
       return out;
     }
@@ -41,7 +41,7 @@ namespace dplyr {
     virtual SEXP process(const SlicingIndex& index) {
       int nrows = index.size();
       Vector<RTYPE> out = no_init(nrows);
-      SlicingIndex fake(0, nrows);
+      NaturalSlicingIndex fake(nrows);
       static_cast<Derived&>(*this).process_slice(out, index, fake);
       return out;
     }

--- a/inst/include/dplyr/Result/Rank.h
+++ b/inst/include/dplyr/Result/Rank.h
@@ -243,7 +243,7 @@ namespace dplyr {
       GroupedDataFrame::group_iterator git = gdf.group_begin();
       IntegerVector out(n);
       for (int i=0; i<ng; i++, ++git) {
-        SlicingIndex index = *git;
+        const SlicingIndex& index = *git;
 
         // tmp <- 0:(m-1)
         int m = index.size();
@@ -322,7 +322,7 @@ namespace dplyr {
       GroupedDataFrame::group_iterator git = gdf.group_begin();
       IntegerVector out(n);
       for (int i=0; i<ng; i++, ++git) {
-        SlicingIndex index = *git;
+        const SlicingIndex& index = *git;
 
         // tmp <- 0:(m-1)
         int m = index.size();
@@ -395,7 +395,7 @@ namespace dplyr {
       IntegerVector res = no_init(n);
       GroupedDataFrame::group_iterator git = gdf.group_begin();
       for (int i=0; i<ng; i++, ++git) {
-        SlicingIndex index = *git;
+        const SlicingIndex& index = *git;
         int m = index.size();
         for (int j=0; j<m; j++) res[index[j]] = j + 1;
       }

--- a/inst/include/dplyr/RowwiseDataFrame.h
+++ b/inst/include/dplyr/RowwiseDataFrame.h
@@ -16,8 +16,8 @@ namespace dplyr {
       return *this;
     }
 
-    SlicingIndex operator*() const {
-      return SlicingIndex(IntegerVector::create(i), i);
+    FullSlicingIndex operator*() const {
+      return FullSlicingIndex(IntegerVector::create(i), i);
     }
 
     int i;

--- a/inst/include/dplyr/RowwiseDataFrame.h
+++ b/inst/include/dplyr/RowwiseDataFrame.h
@@ -16,8 +16,8 @@ namespace dplyr {
       return *this;
     }
 
-    FullSlicingIndex operator*() const {
-      return FullSlicingIndex(IntegerVector::create(i), i);
+    GroupedSlicingIndex operator*() const {
+      return GroupedSlicingIndex(IntegerVector::create(i), i);
     }
 
     int i;

--- a/inst/include/dplyr/RowwiseDataFrame.h
+++ b/inst/include/dplyr/RowwiseDataFrame.h
@@ -26,7 +26,7 @@ namespace dplyr {
   class RowwiseDataFrame {
   public:
     typedef RowwiseDataFrameIndexIterator group_iterator;
-    typedef RowwiseSlicingIndex SlicingIndex;
+    typedef RowwiseSlicingIndex slicing_index;
 
     RowwiseDataFrame(SEXP x):
       data_(x),

--- a/inst/include/dplyr/RowwiseDataFrame.h
+++ b/inst/include/dplyr/RowwiseDataFrame.h
@@ -16,8 +16,8 @@ namespace dplyr {
       return *this;
     }
 
-    GroupedSlicingIndex operator*() const {
-      return GroupedSlicingIndex(IntegerVector::create(i), i);
+    RowwiseSlicingIndex operator*() const {
+      return RowwiseSlicingIndex(i);
     }
 
     int i;
@@ -26,6 +26,8 @@ namespace dplyr {
   class RowwiseDataFrame {
   public:
     typedef RowwiseDataFrameIndexIterator group_iterator;
+    typedef RowwiseSlicingIndex SlicingIndex;
+
     RowwiseDataFrame(SEXP x):
       data_(x),
       group_sizes()

--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -42,7 +42,9 @@ public:
   }
 
   inline int operator[](int i) const {
-    return i + start;
+    if (i != 0)
+      stop("Can only use 0 for RowwiseSlicingIndex, queried %d", i);
+    return start;
   }
 
   inline int group() const {
@@ -62,6 +64,8 @@ public:
   }
 
   virtual int operator[](int i) const {
+    if (i < 0 || i >= n)
+      stop("Out of bounds index %d queried for NaturalSlicingIndex", i);
     return i;
   }
 
@@ -87,6 +91,8 @@ public:
   }
 
   inline int operator[](int i) const {
+    if (i < 0 || i >= n)
+      stop("Out of bounds index %d queried for OffsetSlicingIndex", i);
     return i + start;
   }
 

--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -25,7 +25,7 @@ public:
     return group_index;
   }
 
-// private:
+private:
   IntegerVector data;
   int group_index;
 };

--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -11,10 +11,10 @@ public:
   };
 };
 
-class FullSlicingIndex : public SlicingIndex {
+class GroupedSlicingIndex : public SlicingIndex {
 public:
-  FullSlicingIndex(IntegerVector data_) : data(data_), group_index(-1) {}
-  FullSlicingIndex(IntegerVector data_, int group_) : data(data_), group_index(group_) {}
+  GroupedSlicingIndex(IntegerVector data_) : data(data_), group_index(-1) {}
+  GroupedSlicingIndex(IntegerVector data_, int group_) : data(data_), group_index(group_) {}
 
   virtual int size() const {
     return data.size();

--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -33,6 +33,26 @@ private:
   int group_index;
 };
 
+class RowwiseSlicingIndex : public SlicingIndex {
+public:
+  RowwiseSlicingIndex(const int start_) : start(start_) {}
+
+  inline int size() const {
+    return 1;
+  }
+
+  inline int operator[](int i) const {
+    return i + start;
+  }
+
+  inline int group() const {
+    return start;
+  }
+
+private:
+  int start;
+};
+
 class NaturalSlicingIndex : public SlicingIndex {
 public:
   NaturalSlicingIndex(const int n_) : n(n_) {}

--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -1,6 +1,9 @@
 #ifndef dplyr_tools_SlicingIndex_H
 #define dplyr_tools_SlicingIndex_H
 
+// A SlicingIndex allows specifying which rows of a data frame are selected in which order, basically a 0:n -> 0:m map.
+// It also can be used to split a data frame in groups.
+// Important special cases can be implemented without materializing the map.
 class SlicingIndex {
 public:
   virtual int size() const = 0;
@@ -11,6 +14,10 @@ public:
   };
 };
 
+// A GroupedSlicingIndex is the most general slicing index,
+// the 0:n -> 0:m map is specified and stored as an IntegerVector.
+// A group identifier can be assigned on construction.
+// It is used in grouped operations (group_by()).
 class GroupedSlicingIndex : public SlicingIndex {
 public:
   GroupedSlicingIndex(IntegerVector data_) : data(data_), group_index(-1) {}
@@ -33,6 +40,8 @@ private:
   int group_index;
 };
 
+// A RowwiseSlicingIndex selects a single row, which is also the group ID by definition.
+// It is used in rowwise operations (rowwise()).
 class RowwiseSlicingIndex : public SlicingIndex {
 public:
   RowwiseSlicingIndex(const int start_) : start(start_) {}
@@ -55,6 +64,9 @@ private:
   int start;
 };
 
+// A NaturalSlicingIndex selects an entire data frame as a single group.
+// It is used when the entire data frame needs to be processed by a processor that expects a SlicingIndex
+// to address the rows.
 class NaturalSlicingIndex : public SlicingIndex {
 public:
   NaturalSlicingIndex(const int n_) : n(n_) {}
@@ -82,6 +94,8 @@ private:
   int n;
 };
 
+// An OffsetSlicingIndex selects a consecutive part of a data frame, starting at a specific row.
+// It is used for binding data frames vertically (bind_rows()).
 class OffsetSlicingIndex : public SlicingIndex {
 public:
   OffsetSlicingIndex(const int start_, const int n_) : start(start_), n(n_) {}

--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -3,31 +3,79 @@
 
 class SlicingIndex {
 public:
+  virtual int size() const = 0;
+  virtual int operator[](int i) const = 0;
+  virtual int group() const = 0;
+  virtual bool is_identity(SEXP x) const {
+    return FALSE;
+  };
+};
 
-  SlicingIndex(IntegerVector data_) : data(data_), group_index(-1) {}
-  SlicingIndex(IntegerVector data_, int group_) : data(data_), group_index(group_) {}
+class FullSlicingIndex : public SlicingIndex {
+public:
+  FullSlicingIndex(IntegerVector data_) : data(data_), group_index(-1) {}
+  FullSlicingIndex(IntegerVector data_, int group_) : data(data_), group_index(group_) {}
 
-  SlicingIndex(int start, int n) : data(0), group_index(-1) {
-    if (n>0) {
-      data = seq(start, start + n - 1);
-    }
-  }
-
-  inline int size() const {
+  virtual int size() const {
     return data.size();
   }
 
-  inline int operator[](int i) const {
+  virtual int operator[](int i) const {
     return data[i];
   }
 
-  inline int group() const {
+  virtual int group() const {
     return group_index;
   }
 
 private:
   IntegerVector data;
   int group_index;
+};
+
+class NaturalSlicingIndex : public SlicingIndex {
+public:
+  NaturalSlicingIndex(const int n_) : n(n_) {}
+
+  virtual int size() const {
+    return n;
+  }
+
+  virtual int operator[](int i) const {
+    return i;
+  }
+
+  virtual int group() const {
+    return -1;
+  }
+
+  virtual bool is_identity(SEXP x) const {
+    const R_len_t length = Rf_length(x);
+    return length == n;
+  }
+
+private:
+  int n;
+};
+
+class OffsetSlicingIndex : public SlicingIndex {
+public:
+  OffsetSlicingIndex(const int start_, const int n_) : start(start_), n(n_) {}
+
+  inline int size() const {
+    return n;
+  }
+
+  inline int operator[](int i) const {
+    return i + start;
+  }
+
+  inline int group() const {
+    return -1;
+  }
+
+private:
+  int start, n;
 };
 
 #endif

--- a/src/distinct.cpp
+++ b/src/distinct.cpp
@@ -47,7 +47,7 @@ SEXP n_distinct_multi(List variables, bool na_rm = false) {
   }
 
   MultipleVectorVisitors visitors(variables);
-  SlicingIndex everything(0, visitors.nrows());
+  NaturalSlicingIndex everything(visitors.nrows());
   if (na_rm) {
     Count_Distinct_Narm<MultipleVectorVisitors> counter(visitors);
     return counter.process(everything);

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -123,7 +123,7 @@ DataFrame filter_grouped_single_env(const Data& gdf, const LazyDots& dots) {
   int ngroups = gdf.ngroups();
   typename Data::group_iterator git = gdf.group_begin();
   for (int i=0; i<ngroups; i++, ++git) {
-    SlicingIndex indices = *git;
+    const SlicingIndex& indices = *git;
     int chunk_size = indices.size();
 
     g_test = check_filter_logical_result(call_proxy.get(indices));
@@ -166,7 +166,7 @@ DataFrame filter_grouped_multiple_env(const Data& gdf, const LazyDots& dots) {
     int ngroups = gdf.ngroups();
     typename Data::group_iterator git = gdf.group_begin();
     for (int i=0; i<ngroups; i++, ++git) {
-      SlicingIndex indices = *git;
+      const SlicingIndex& indices = *git;
       int chunk_size = indices.size();
 
       g_test  = check_filter_logical_result(call_proxy.get(indices));

--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -23,7 +23,7 @@ IntegerVector grouped_indices_grouped_df_impl(GroupedDataFrame gdf) {
   int ngroups = gdf.ngroups();
   GroupedDataFrameIndexIterator it = gdf.group_begin();
   for (int i=0; i<ngroups; i++, ++it) {
-    SlicingIndex index = *it;
+    const SlicingIndex& index = *it;
     int n_index = index.size();
     for (int j=0; j<n_index; j++) {
       res[ index[j] ] = i + 1;

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -136,21 +136,3 @@ namespace dplyr {
 void registerHybridHandler(const char* name, HybridHandler proto) {
   get_handlers()[Rf_install(name)] = proto;
 }
-
-bool can_simplify(SEXP call) {
-  if (TYPEOF(call) == LISTSXP) {
-    bool res = can_simplify(CAR(call));
-    if (res) return true;
-    return can_simplify(CDR(call));
-  }
-
-  if (TYPEOF(call) == LANGSXP) {
-    SEXP fun_symbol = CAR(call);
-    if (TYPEOF(fun_symbol) != SYMSXP) return false;
-
-    if (get_handlers().count(fun_symbol)) return true;
-
-    return can_simplify(CDR(call));
-  }
-  return false;
-}

--- a/src/join_exports.cpp
+++ b/src/join_exports.cpp
@@ -414,7 +414,7 @@ SEXP slice_grouped(GroupedDataFrame gdf, const LazyDots& dots) {
   int ngroups = gdf.ngroups();
   GroupedDataFrame::group_iterator git = gdf.group_begin();
   for (int i=0; i<ngroups; i++, ++git) {
-    SlicingIndex indices = *git;
+    const SlicingIndex& indices = *git;
     int nr = indices.size();
     g_test = check_filter_integer_result(call_proxy.get(indices));
     CountIndices counter(indices.size(), g_test);

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -27,12 +27,13 @@ SEXP summarise_grouped(const DataFrame& df, const LazyDots& dots) {
   int nvars = gdf.nvars();
   check_not_groups(dots, gdf);
 
-  LOG_VERBOSE << "copying data to accumulator";
+  LOG_VERBOSE << "copying " << nvars << " variables to accumulator";
 
   NamedListAccumulator<Data> accumulator;
   int i=0;
   List results(nvars + nexpr);
   for (; i<nvars; i++) {
+    LOG_VERBOSE << "copying " << CHAR(PRINTNAME(gdf.symbol(i)));
     results[i] = shared_SEXP(gdf.label(i));
     accumulator.set(PRINTNAME(gdf.symbol(i)), results[i]);
   }
@@ -41,6 +42,7 @@ SEXP summarise_grouped(const DataFrame& df, const LazyDots& dots) {
 
   Subsets subsets(gdf);
   for (int k=0; k<nexpr; k++, i++) {
+    LOG_VERBOSE << "processing variable " << k;
     Rcpp::checkUserInterrupt();
     const Lazy& lazy = dots[k];
     const Environment& env = lazy.env();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -79,7 +79,6 @@ void copy_attributes(SEXP out, SEXP data) {
 
 // effectively the same as copy_attributes but without names and dims
 void copy_most_attributes(SEXP out, SEXP data) {
-  LOG_VERBOSE << "copying attributes (except names and dim): " << CharacterVector(List(ATTRIB(data)).names());
   Rf_copyMostAttrib(data, out);
 }
 


### PR DESCRIPTION
- allows removing redundant code
- preparation for hybrid evaluation refactoring
- reduces allocations
- a template solution (instead of virtual functions) may give better performance, can be refactored later

@hadley: PTAL.