### PR TITLE
enforce integer 'n' for lag()

### DIFF
--- a/R/translate-sql-base.r
+++ b/R/translate-sql-base.r
@@ -203,7 +203,7 @@ base_win <- sql_translator(
   },
   lag = function(x, n = 1L, default = NA, order = NULL) {
     over(
-      build_sql("LAG", list(x, n, default)),
+      build_sql("LAG", list(x, as.integer(n), default)),
       partition_group(),
       order %||% partition_order()
     )


### PR DESCRIPTION
This resolves an issue in stricter SQL engines where `double` values are not accepted.
