### PR TITLE
Test for #2224

### DIFF
--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -256,3 +256,15 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
   df <- data_frame(a = 1:3, b = as.raw(1:3))
   expect_error( rowwise(df), "unsupported type" )
 })
+
+    
+test_that("group_by will not execute column names as code #2224", {
+  df <- mtcars
+  colnames(df) <- paste(colnames(df), 1:ncol(df))
+  
+  # This line will throw an error if column names are executed
+  prepared <- group_by_prepare(df, .dots = names(df))
+  template <- list(data = df, groups = lapply(names(df), as.name))
+  expect_identical(prepared, template)
+)
+})


### PR DESCRIPTION
This test currently fails because dplyr tries to run the column names as code (#2224); it will succeed once the column names are coerced to text.