### PR TITLE
Add failing tests for summarize preserving ordered factors (#2200)

### DIFF
--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -743,30 +743,25 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
 })
 
 test_that("calculating an ordered factor preserves order (#2200)", {
-  test_df <- data_frame(id = rep(letters[24:26], 2),
-                 val = runif(6, 0, 4))
-
-  make_levels <- function(x) {
-    cut(x, breaks = 0:4, labels = LETTERS[1:4], ordered_result = TRUE)
-  }
+  test_df <- tibble(id = c("a", "b"), val = 1:2)
 
   ret <- group_by(test_df, id) %>%
-    summarize(mean_val = mean(val),
-              level = make_levels(mean_val))
-  expect_is(ret$level, "ordered")
-  expect_equal(levels(ret$level), levels(make_levels(1)))
+    summarize(level = ordered(val))
+
+  expect_s3_class(ret$level, "ordered")
+  expect_equal(levels(ret$level), c("1","2"))
 })
 
 test_that("min, max preserves ordered factor data  (#2200)", {
-  test_df <- data_frame(id = rep(letters[24:26], 2),
-                        ord = as.ordered(
-                          sample(LETTERS[1:3], 6, replace = TRUE)))
+  test_df <- tibble(id = rep(c("a","b"), 2),
+                    ord = ordered(c("A", "B", "B", "A"), levels = c("A", "B")))
 
   ret <- group_by(test_df, id) %>%
     summarize(min_ord = min(ord),
               max_ord = max(ord))
-  expect_is(ret$min_ord, "ordered")
-  expect_is(ret$max_ord, "ordered")
+
+  expect_s3_class(ret$min_ord, "ordered")
+  expect_s3_class(ret$max_ord, "ordered")
   expect_equal(levels(ret$min_ord), levels(test_df$ord))
   expect_equal(levels(ret$max_ord), levels(test_df$ord))
 })

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -744,10 +744,15 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
 
 test_that("calculating an ordered factor preserves order (#2200)", {
   skip("Currently failing")
-  test_df <- tibble(id = c("a", "b"), val = 1:2)
+  test_df <- tibble(
+    id = c("a", "b"),
+    val = 1:2
+  )
 
   ret <- group_by(test_df, id) %>%
-    summarize(level = ordered(val))
+    summarize(
+      level = ordered(val)
+    )
 
   expect_s3_class(ret$level, "ordered")
   expect_equal(levels(ret$level), c("1","2"))
@@ -755,13 +760,16 @@ test_that("calculating an ordered factor preserves order (#2200)", {
 
 test_that("min, max preserves ordered factor data  (#2200)", {
   skip("Currently failing")
-  test_df <- tibble(id = rep(c("a","b"), 2),
-                    ord = ordered(c("A", "B", "B", "A"),
-                                  levels = c("A", "B")))
+  test_df <- tibble(
+    id = rep(c("a","b"), 2),
+    ord = ordered(c("A", "B", "B", "A"), levels = c("A", "B"))
+  )
 
   ret <- group_by(test_df, id) %>%
-    summarize(min_ord = min(ord),
-              max_ord = max(ord))
+    summarize(
+      min_ord = min(ord),
+      max_ord = max(ord)
+    )
 
   expect_s3_class(ret$min_ord, "ordered")
   expect_s3_class(ret$max_ord, "ordered")

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -742,7 +742,7 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
     "can't promote")
 })
 
-test_that("calculating an ordered factor inside summarize on grouped df preserves order (#2200)", {
+test_that("calculating an ordered factor preserves order (#2200)", {
   test_df <- data_frame(id = rep(letters[24:26], 2),
                  val = runif(6, 0, 4))
 

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -756,7 +756,8 @@ test_that("calculating an ordered factor preserves order (#2200)", {
 test_that("min, max preserves ordered factor data  (#2200)", {
   skip("Currently failing")
   test_df <- tibble(id = rep(c("a","b"), 2),
-                    ord = ordered(c("A", "B", "B", "A"), levels = c("A", "B")))
+                    ord = ordered(c("A", "B", "B", "A"),
+                                  levels = c("A", "B")))
 
   ret <- group_by(test_df, id) %>%
     summarize(min_ord = min(ord),

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -743,6 +743,7 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
 })
 
 test_that("calculating an ordered factor preserves order (#2200)", {
+  skip("Currently failing")
   test_df <- tibble(id = c("a", "b"), val = 1:2)
 
   ret <- group_by(test_df, id) %>%
@@ -753,6 +754,7 @@ test_that("calculating an ordered factor preserves order (#2200)", {
 })
 
 test_that("min, max preserves ordered factor data  (#2200)", {
+  skip("Currently failing")
   test_df <- tibble(id = rep(c("a","b"), 2),
                     ord = ordered(c("A", "B", "B", "A"), levels = c("A", "B")))
 

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -741,3 +741,32 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
       .$a,
     "can't promote")
 })
+
+test_that("calculating an ordered factor inside summarize on grouped df preserves order (#2200)", {
+  test_df <- data_frame(id = rep(letters[24:26], 2),
+                 val = runif(6, 0, 4))
+
+  make_levels <- function(x) {
+    cut(x, breaks = 0:4, labels = LETTERS[1:4], ordered_result = TRUE)
+  }
+
+  ret <- group_by(test_df, id) %>%
+    summarize(mean_val = mean(val),
+              level = make_levels(mean_val))
+  expect_is(ret$level, "ordered")
+  expect_equal(levels(ret$level), levels(make_levels(1)))
+})
+
+test_that("min, max preserves ordered factor data  (#2200)", {
+  test_df <- data_frame(id = rep(letters[24:26], 2),
+                        ord = as.ordered(
+                          sample(LETTERS[1:3], 6, replace = TRUE)))
+
+  ret <- group_by(test_df, id) %>%
+    summarize(min_ord = min(ord),
+              max_ord = max(ord))
+  expect_is(ret$min_ord, "ordered")
+  expect_is(ret$max_ord, "ordered")
+  expect_equal(levels(ret$min_ord), levels(test_df$ord))
+  expect_equal(levels(ret$max_ord), levels(test_df$ord))
+})


### PR DESCRIPTION
Two tests added for #2200 :
- One where an ordered factor is created inside `summarize` (order gets dropped)
- One where `min` and `max` are calculated on an already existing ordered factor column (order gets dropped)