### PR TITLE
added a test case addressing issue 2228 (join hangs on empty suffix a…

### DIFF
--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -614,6 +614,8 @@ test_that( "left_join handles mix of encodings in column names (#1571)", {
 })
 
 test_that("can handle empty string in suffix argument, left side (#2228, #2182, #2007)", {
+   skip( "not yet resolved, would cause stack overflow" )
+   
    j1 <- inner_join(e, f, "x", suffix = c("", "2"))
    j2 <- left_join(e, f, "x", suffix = c("", "2"))
    j3 <- right_join(e, f, "x", suffix = c("", "2"))
@@ -626,6 +628,8 @@ test_that("can handle empty string in suffix argument, left side (#2228, #2182, 
 })
 
 test_that("can handle empty string in suffix argument, right side (#2228, #2182, #2007)", {
+   skip( "not yet resolved, would cause stack overflow" )
+
    j1 <- inner_join(e, f, "x", suffix = c("1", ""))
    j2 <- left_join(e, f, "x", suffix = c("1", ""))
    j3 <- right_join(e, f, "x", suffix = c("1", ""))

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -612,3 +612,27 @@ test_that( "left_join handles mix of encodings in column names (#1571)", {
   expect_equal( res[["l\u00f8penummer"]], 1:6)
 
 })
+
+test_that("can handle empty string in suffix argument, left side (#2228, #2182, #2007)", {
+   j1 <- inner_join(e, f, "x", suffix = c("", "2"))
+   j2 <- left_join(e, f, "x", suffix = c("", "2"))
+   j3 <- right_join(e, f, "x", suffix = c("", "2"))
+   j4 <- full_join(e, f, "x", suffix = c("", "2"))
+   
+   expect_named(j1, c("x", "z", "z2"))
+   expect_named(j2, c("x", "z", "z2"))
+   expect_named(j3, c("x", "z", "z2"))
+   expect_named(j4, c("x", "z", "z2"))
+})
+
+test_that("can handle empty string in suffix argument, right side (#2228, #2182, #2007)", {
+   j1 <- inner_join(e, f, "x", suffix = c("1", ""))
+   j2 <- left_join(e, f, "x", suffix = c("1", ""))
+   j3 <- right_join(e, f, "x", suffix = c("1", ""))
+   j4 <- full_join(e, f, "x", suffix = c("1", ""))
+   
+   expect_named(j1, c("x", "z1", "z"))
+   expect_named(j2, c("x", "z1", "z"))
+   expect_named(j3, c("x", "z1", "z"))
+   expect_named(j4, c("x", "z1", "z"))
+})


### PR DESCRIPTION
…rgument)

See https://github.com/hadley/dplyr/issues/2228

At the moment, the test case added here cause R to hang in and end-less loop, then crashing due to stack overflow. So, better pull this request only after you fixed the issue. ;)