### PR TITLE
Add Failing Test for #1892 and a Related Failing Test

### DIFF
--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -276,11 +276,11 @@ test_that("grouped mutate coerces factor + character -> character (WARN)", {
     id = c(1, 4),
     value = factor(c("blue", NA)),
     group = c("A", "B")
-  )
+  ) %>%
+    group_by(group)
 
   expect_warning(
     df <- df %>%
-      group_by(group) %>%
       mutate(value = ifelse(id > 3, as.character("foo"), value))
   )
 

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -260,9 +260,9 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
 test_that("group_by coerces integer + double -> double (#1892)", {
   skip("Currently failing")
   data_frame(
-    id = c(1,2,3,4,5,6),
-    value = c(1L,2L,3L,NA,NA,NA),
-    group = c("A","A","A","B","B","B")
+    id = c(1, 2, 3, 4, 5, 6),
+    value = c(1L, 2L, 3L, NA, NA, NA),
+    group = c("A", "A", "A", "B", "B", "B")
   ) %>%
   group_by(group) %>%
   mutate(value = ifelse(is.na(value),double(0),value))

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -265,5 +265,6 @@ test_that("group_by coerces integer + double -> double (#1892)", {
     group = c("A", "A", "A", "B", "B", "B")
   ) %>%
   group_by(group) %>%
-  mutate(value = ifelse(is.na(value),double(0),value))
+  mutate(value = ifelse(is.na(value), as.double(0), value))
+})
 })

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -257,7 +257,7 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
   expect_error( rowwise(df), "unsupported type" )
 })
 
-test_that("group_by coherses types to most general common data type (#1892)", {
+test_that("group_by coherses integer + double -> double (#1892)", {
   data_frame(
     id = c(1,2,3,4,5,6),
     value = c(1L,2L,3L,NA,NA,NA),

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -256,33 +256,3 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
   df <- data_frame(a = 1:3, b = as.raw(1:3))
   expect_error( rowwise(df), "unsupported type" )
 })
-
-test_that("grouped mutate coerces integer + double -> double (#1892)", {
-  skip("Currently failing")
-  df <- data_frame(
-    id = c(1, 4),
-    value = c(1L, NA),
-    group = c("A", "B")
-  ) %>%
-    group_by(group) %>%
-    mutate(value = ifelse(is.na(value), as.double(0), value))
-  expect_type(df$value, "double")
-})
-
-test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)", {
-  skip("Currently failing")
-
-  df <- data_frame(
-    id = c(1, 4),
-    value = factor(c("blue", NA)),
-    group = c("A", "B")
-  ) %>%
-    group_by(group)
-
-  expect_warning(
-    df <- df %>%
-      mutate(value = ifelse(id > 3, as.character("foo"), value))
-  )
-
-  expect_type(df$value, "character")
-})

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -266,7 +266,7 @@ test_that("group_by coerces integer + double -> double (#1892)", {
   ) %>%
     group_by(group) %>%
     mutate(value = ifelse(is.na(value), as.double(0), value))
-  expect_equal(class(df$value), "double")
+  expect_equal(typeof(df$value), "double")
 })
 
 test_that("group_by coerces factor + character -> character (WARN)", {
@@ -280,5 +280,5 @@ test_that("group_by coerces factor + character -> character (WARN)", {
     group_by(group) %>%
     mutate(value = ifelse(id > 3, as.character("foo"), value))
   )
-  expect_equal(class(df$value), "character")
+  expect_equal(typeof(df$value), "character")
 })

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -257,7 +257,7 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
   expect_error( rowwise(df), "unsupported type" )
 })
 
-test_that("group_by coherses integer + double -> double (#1892)", {
+test_that("group_by coerces integer + double -> double (#1892)", {
   data_frame(
     id = c(1,2,3,4,5,6),
     value = c(1L,2L,3L,NA,NA,NA),

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -259,12 +259,13 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
 
 test_that("group_by coerces integer + double -> double (#1892)", {
   skip("Currently failing")
-  data_frame(
+  df <- data_frame(
     id = c(1, 2, 3, 4, 5, 6),
     value = c(1L, 2L, 3L, NA, NA, NA),
     group = c("A", "A", "A", "B", "B", "B")
   ) %>%
-  group_by(group) %>%
-  mutate(value = ifelse(is.na(value), as.double(0), value))
+    group_by(group) %>%
+    mutate(value = ifelse(is.na(value), as.double(0), value))
+  expect_equal(class(df$value), "double")
 })
 })

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -271,14 +271,18 @@ test_that("grouped mutate coerces integer + double -> double (#1892)", {
 
 test_that("grouped mutate coerces factor + character -> character (WARN)", {
   skip("Currently failing")
-  expect_warning(
-    df <- data_frame(
-      id = c(1, 4),
-      value = factor(c("blue", NA)),
-      group = c("A", "B")
-    ) %>%
-    group_by(group) %>%
-    mutate(value = ifelse(id > 3, as.character("foo"), value))
+
+  df <- data_frame(
+    id = c(1, 4),
+    value = factor(c("blue", NA)),
+    group = c("A", "B")
   )
+
+  expect_warning(
+    df <- df %>%
+      group_by(group) %>%
+      mutate(value = ifelse(id > 3, as.character("foo"), value))
+  )
+
   expect_type(df$value, "character")
 })

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -268,4 +268,17 @@ test_that("group_by coerces integer + double -> double (#1892)", {
     mutate(value = ifelse(is.na(value), as.double(0), value))
   expect_equal(class(df$value), "double")
 })
+
+test_that("group_by coerces factor + character -> character (WARN)", {
+  skip("Currently failing")
+  expect_warning(
+    df <- data_frame(
+      id = c(1, 2, 3, 4, 5, 6),
+      value = factor(c("blue", "blue", "red", NA, NA, NA)),
+      group = c("A", "A", "A", "B", "B", "B")
+    ) %>%
+    group_by(group) %>%
+    mutate(value = ifelse(id > 3, as.character("foo"), value))
+  )
+  expect_equal(class(df$value), "character")
 })

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -258,6 +258,7 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
 })
 
 test_that("group_by coerces integer + double -> double (#1892)", {
+  skip("Currently failing")
   data_frame(
     id = c(1,2,3,4,5,6),
     value = c(1L,2L,3L,NA,NA,NA),

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -269,7 +269,7 @@ test_that("grouped mutate coerces integer + double -> double (#1892)", {
   expect_type(df$value, "double")
 })
 
-test_that("grouped mutate coerces factor + character -> character (WARN)", {
+test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)", {
   skip("Currently failing")
 
   df <- data_frame(

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -257,28 +257,28 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
   expect_error( rowwise(df), "unsupported type" )
 })
 
-test_that("group_by coerces integer + double -> double (#1892)", {
+test_that("grouped mutate coerces integer + double -> double (#1892)", {
   skip("Currently failing")
   df <- data_frame(
-    id = c(1, 2, 3, 4, 5, 6),
-    value = c(1L, 2L, 3L, NA, NA, NA),
-    group = c("A", "A", "A", "B", "B", "B")
+    id = c(1, 4),
+    value = c(1L, NA),
+    group = c("A", "B")
   ) %>%
     group_by(group) %>%
     mutate(value = ifelse(is.na(value), as.double(0), value))
-  expect_equal(typeof(df$value), "double")
+  expect_type(df$value, "double")
 })
 
-test_that("group_by coerces factor + character -> character (WARN)", {
+test_that("grouped mutate coerces factor + character -> character (WARN)", {
   skip("Currently failing")
   expect_warning(
     df <- data_frame(
-      id = c(1, 2, 3, 4, 5, 6),
-      value = factor(c("blue", "blue", "red", NA, NA, NA)),
-      group = c("A", "A", "A", "B", "B", "B")
+      id = c(1, 4),
+      value = factor(c("blue", NA)),
+      group = c("A", "B")
     ) %>%
     group_by(group) %>%
     mutate(value = ifelse(id > 3, as.character("foo"), value))
   )
-  expect_equal(typeof(df$value), "character")
+  expect_type(df$value, "character")
 })

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -256,3 +256,13 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
   df <- data_frame(a = 1:3, b = as.raw(1:3))
   expect_error( rowwise(df), "unsupported type" )
 })
+
+test_that("group_by coherses types to most general common data type (#1892)", {
+  data_frame(
+    id = c(1,2,3,4,5,6),
+    value = c(1L,2L,3L,NA,NA,NA),
+    group = c("A","A","A","B","B","B")
+  ) %>%
+  group_by(group) %>%
+  mutate(value = ifelse(is.na(value),double(0),value))
+})

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -555,6 +555,33 @@ test_that("grouped mutate errors on incompatible column type (#1641)", {
   expect_error( mutate(df, foo = mean), 'Unsupported type CLOSXP for column "foo"')
 })
 
+test_that("grouped mutate coerces integer + double -> double (#1892)", {
+  skip("Currently failing")
+  df <- data_frame(
+    id = c(1, 4),
+    value = c(1L, NA),
+    group = c("A", "B")
+  ) %>%
+    group_by(group) %>%
+    mutate(value = ifelse(is.na(value), as.double(0), value))
+  expect_type(df$value, "double")
+})
+
+test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)", {
+  skip("Currently failing")
+  df <- data_frame(
+    id = c(1, 4),
+    value = factor(c("blue", NA)),
+    group = c("A", "B")
+  ) %>%
+    group_by(group)
+  expect_warning(
+    df <- df %>%
+      mutate(value = ifelse(id > 3, as.character("foo"), value))
+  )
+  expect_type(df$value, "character")
+})
+
 test_that("lead/lag works on more complex expressions (#1588)", {
   df <- data_frame(x = rep(1:5,2), g = rep(1:2, each = 5) ) %>% group_by(g)
   res <- df %>% mutate( y = lead(x > 3) )

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -563,9 +563,9 @@ test_that("grouped mutate coerces integer + double -> double (#1892)", {
     group = c("A", "B")
   ) %>%
     group_by(group) %>%
-    mutate(value = ifelse(is.na(value), as.double(0), value))
+    mutate(value = ifelse(is.na(value), 0, value))
   expect_type(df$value, "double")
-  expect_identical(df$value, c(as.double(0), as.double(1)))
+  expect_identical(df$value, c(0, 1))
 })
 
 test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)", {
@@ -578,7 +578,7 @@ test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)
     group_by(group)
   expect_warning(
     df <- df %>%
-      mutate(value = ifelse(id > 3, as.character("foo"), value))
+      mutate(value = ifelse(id > 3, "foo", value))
   )
   expect_type(df$value, "character")
   expect_identical(df$value, c("blue", "foo"))

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -565,6 +565,7 @@ test_that("grouped mutate coerces integer + double -> double (#1892)", {
     group_by(group) %>%
     mutate(value = ifelse(is.na(value), as.double(0), value))
   expect_type(df$value, "double")
+  expect_identical(df$value, c(as.double(0), as.double(1)))
 })
 
 test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)", {
@@ -580,6 +581,7 @@ test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)
       mutate(value = ifelse(id > 3, as.character("foo"), value))
   )
   expect_type(df$value, "character")
+  expect_identical(df$value, c("blue", "foo"))
 })
 
 test_that("lead/lag works on more complex expressions (#1588)", {


### PR DESCRIPTION
This PR adds the failing test associated with https://github.com/hadley/dplyr/issues/1892 (`group_by coerces integer + double -> double (#1892)`) and another (apparently related) failing test (`group_by coerces factor + character -> character (WARN)`).  Please confirm that the second failing test is indeed an issue and not a misunderstanding on my part before merging.