### PR TITLE
fix and test for issue #2256

### DIFF
--- a/R/data-temp.r
+++ b/R/data-temp.r
@@ -20,13 +20,15 @@ NULL
 #' @export
 #' @rdname testing
 test_register_src <- function(name, src) {
-  message("Registering testing src: ", name, " ", appendLF = FALSE)
+  message("Registering testing src: ", name)
   tryCatch(
     {
       test_srcs$add(name, src)
-      message("OK")
+      message("OK: ", name, " registered")
     },
-    error = function(e) message(conditionMessage(e))
+    error = function(e) {
+      message("Failed: ", name, " not registered")
+    }
   )
 }
 

--- a/R/src-mysql.r
+++ b/R/src-mysql.r
@@ -145,7 +145,9 @@ db_has_table.MySQLConnection <- function(con, table, ...) {
 #' @export
 db_data_type.MySQLConnection <- function(con, fields, ...) {
   char_type <- function(x) {
-    n <- max(nchar(as.character(x), "bytes"))
+    x <- as.character(x)
+    x <- vapply(x, encodeString, character(1))
+    n <- max(nchar(x), "bytes")
     if (n <= 65535) {
       paste0("varchar(", n, ")")
     } else {

--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -395,9 +395,6 @@ collect.tbl_sql <- function(x, ..., n = 1e5, warn_incomplete = TRUE) {
 
   out <- dbFetch(res, n)
 
-  # Re-write encoded "<NA>" values to NA
-  out[out=="<NA>"] <- NA
-
   if (warn_incomplete) {
     res_warn_incomplete(res, "n = Inf")
   }

--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -394,6 +394,10 @@ collect.tbl_sql <- function(x, ..., n = 1e5, warn_incomplete = TRUE) {
   on.exit(dbClearResult(res))
 
   out <- dbFetch(res, n)
+
+  # Re-write encoded "<NA>" values to NA
+  out[out=="<NA>"] <- NA
+
   if (warn_incomplete) {
     res_warn_incomplete(res, "n = Inf")
   }

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -15,10 +15,3 @@ skip_if_no_sqlite <- function() {
   if (!test_srcs$has("sqlite"))
     skip("No SQLite")
 }
-
-skip_if_no_mysql <- function() {
-  if (!test_srcs$has("mysql"))
-    skip("No MySQL")
-}
-
-print(test_srcs)

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -5,11 +5,20 @@ if (identical(Sys.info()[["user"]], "hadley")) {
   test_register_src("postgres", src_postgres("test", host = "localhost"))
 } else if (identical(Sys.getenv("TRAVIS"), "true")) {
   test_register_src("postgres", src_postgres("test", user = "travis", password = ""))
+} else if (identical(Sys.info()[["user"]], "eduardgrebe")) {
+  test_register_src("postgres", src_postgres("test", host = "localhost", user = "eduardgrebe", password = ""))
 }
 
-
+test_register_src("mysql", src_mysql("test", host = "localhost"))
 
 skip_if_no_sqlite <- function() {
   if (!test_srcs$has("sqlite"))
     skip("No SQLite")
 }
+
+skip_if_no_mysql <- function() {
+  if (!test_srcs$has("mysql"))
+    skip("No MySQL")
+}
+
+print(test_srcs)

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -1,12 +1,10 @@
 test_register_src("df", src_df(env = new.env(parent = emptyenv())))
 test_register_src("sqlite", src_sqlite(":memory:", create = TRUE))
 
-if (identical(Sys.info()[["user"]], "hadley")) {
-  test_register_src("postgres", src_postgres("test", host = "localhost"))
-} else if (identical(Sys.getenv("TRAVIS"), "true")) {
+if (identical(Sys.getenv("TRAVIS"), "true")) {
   test_register_src("postgres", src_postgres("test", user = "travis", password = ""))
-} else if (identical(Sys.info()[["user"]], "eduardgrebe")) {
-  test_register_src("postgres", src_postgres("test", host = "localhost", user = "eduardgrebe", password = ""))
+} else {
+  test_register_src("postgres", src_postgres("test", host = "localhost"))
 }
 
 test_register_src("mysql", src_mysql("test", host = "localhost"))

--- a/tests/testthat/test-tbl-sql.r
+++ b/tests/testthat/test-tbl-sql.r
@@ -9,3 +9,11 @@ test_that("can generate sql tbls with raw sql", {
     expect_equal(collect(tbl), collect(clone))
   }
 })
+
+test_that("NAs in character fields handled by db sources", {
+  df <- data.frame(x=c("a","aa",NA), stringsAsFactors=FALSE)
+  tbls <- test_load(df, ignore = "df")
+  for (tbl in tbls) {
+    expect_equal(collect(tbl),as.tbl(df))
+  }
+})

--- a/tests/testthat/test-tbl-sql.r
+++ b/tests/testthat/test-tbl-sql.r
@@ -11,9 +11,10 @@ test_that("can generate sql tbls with raw sql", {
 })
 
 test_that("NAs in character fields handled by db sources", {
-  df <- data.frame(x=c("a","aa",NA), stringsAsFactors=FALSE)
+  df <- data.frame(x = c("a", "aa", NA), y = c(NA, "b", "bb"),
+                   z = c("cc", NA, "c"), stringsAsFactors = FALSE)
   tbls <- test_load(df, ignore = "df")
   for (tbl in tbls) {
-    expect_equal(collect(tbl),as.tbl(df))
+    expect_equal(collect(tbl), as.tbl(df))
   }
 })


### PR DESCRIPTION
1. encodeString before checking length of character vectors when writing to mysql source

1. rewrite "<NA>" to NA when reading from database tables with SQL

1. test that dataframe containing NAs in character columns writes correctly to database sources

Fixes #2256.