### PR TITLE
Stop converting colnames to UTF-8 in select()

### DIFF
--- a/R/select-vars.R
+++ b/R/select-vars.R
@@ -83,7 +83,7 @@ select_vars_ <- function(vars, args, include = character(), exclude = character(
 
   # Include/exclude specified variables
   sel <- setNames(vars[incl], names(incl))
-  sel <- c(setdiff2(include, sel), sel)
+  sel <- combine_named_vector(setdiff2(include, sel), sel)
   sel <- setdiff2(sel, exclude)
 
   # Ensure all output vars named
@@ -100,6 +100,11 @@ select_vars_ <- function(vars, args, include = character(), exclude = character(
 
 setdiff2 <- function(x, y) {
   x[match(x, y, 0L) == 0L]
+}
+
+# workaround for the problem that `c` converts names to UTF-8
+combine_named_vector <- function(x, y) {
+  setNames(c(x, y), c(names(x), names(y)))
 }
 
 #' @export

--- a/R/select-vars.R
+++ b/R/select-vars.R
@@ -104,7 +104,8 @@ setdiff2 <- function(x, y) {
 
 # workaround for the problem that `c` converts names to UTF-8
 combine_named_vector <- function(x, y) {
-  setNames(c(x, y), c(names(x), names(y)))
+  setNames(c(x, y),
+           nm = c(names(x) %||% rep("", length(x)), names(y) %||% rep("", length(y))))
 }
 
 #' @export


### PR DESCRIPTION
This PR fixes #2284 by using the temporal workaround for `c()`'s tricky behavior. I am sure that [vctrs](https://github.com/hadley/vctrs) will provide some nice function for this, right? 😄 But, for now, we need some tweak like this.