### PR TITLE
Constant folding and hybrid tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,6 +74,7 @@ Collate:
     'group-indices.R'
     'group-size.r'
     'grouped-df.r'
+    'hybrid.R'
     'id.r'
     'if_else.R'
     'inline.r'

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Expressions in verbs are now interpreted correctly in many cases that failed before (e.g., use of `$`, `case_when()`, nonstandard evaluation, ...). These expressions are now evaluated in a specially constructed temporary environment that retrieves column data on demand with the help of the `bindrcpp` package (#2190). This temporary environment poses restrictions on assignments using `<-` inside verbs.
 
+* Hybrid evaluation is used in more cases now, in particular thanks to constant folding of arguments (#2143) and better support for complex values. Added internal functions for testing the hybrid evaluator (#1691).
+
 * New `add_count()` and `add_tally()` for adding an `n` column within groups (#2078, @dgrtwo).
 
 * Enforce integer `n` for `lag()` (#2162, @kevinushey).

--- a/R/hybrid.R
+++ b/R/hybrid.R
@@ -12,7 +12,7 @@ with_hybrid <- function(expr, ...) {
 
 with_hybrid_ <- function(expr, ...) {
   stopifnot(any(class(expr) == "formula"))
-  expr[[2]] <- call("verify_hybrid", expr[[2]])
+  expr[[2]] <- prepend_call(expr[[2]], "verify_hybrid")
   data <- data_frame(...)
   summarise_(data, out = expr)["out"][[1]]
 }
@@ -24,7 +24,7 @@ without_hybrid <- function(expr, ...) {
 
 without_hybrid_ <- function(expr, ...) {
   stopifnot(any(class(expr) == "formula"))
-  expr[[2]] <- call("verify_not_hybrid", expr[[2]])
+  expr[[2]] <- prepend_call(expr[[2]], "verify_not_hybrid")
   data <- data_frame(...)
   summarise_(data, out = expr)["out"][[1]]
 }
@@ -36,4 +36,15 @@ eval_dots <- function(expr, ...) {
 eval_dots_ <- function(expr, ...) {
   data <- data_frame(...)
   eval(expr[[2]], data, enclos = environment(expr))
+}
+
+# some(func()) -> name(some(func()))
+# list(some(func())) -> list(name(some(func())))
+prepend_call <- function(expr, name) {
+  if (is.call(expr) && expr[[1]] == quote(list)) {
+    stopifnot(length(expr) == 2L)
+    call("list", call(name, expr[[2]]))
+  } else {
+    call(name, expr)
+  }
 }

--- a/R/hybrid.R
+++ b/R/hybrid.R
@@ -1,0 +1,36 @@
+verify_hybrid <- function(x) {
+  stop("Not in hybrid evaluation", call. = FALSE)
+}
+
+verify_not_hybrid <- function(x) {
+  x
+}
+
+with_hybrid <- function(expr, ...) {
+  with_hybrid_(substitute(expr), ...)
+}
+
+with_hybrid_ <- function(expr, ...) {
+  expr <- eval(call("~", call("verify_hybrid", expr)))
+  data <- data_frame(...)
+  summarise_(data, out = expr)["out"][[1]]
+}
+
+without_hybrid <- function(expr, ...) {
+  without_hybrid_(substitute(expr), ...)
+}
+
+without_hybrid_ <- function(expr, ...) {
+  expr <- eval(call("~", call("verify_not_hybrid", expr)))
+  data <- data_frame(...)
+  summarise_(data, out = expr)["out"][[1]]
+}
+
+eval_dots <- function(expr, ...) {
+  eval_dots_(substitute(expr), ...)
+}
+
+eval_dots_ <- function(expr, ...) {
+  data <- data_frame(...)
+  eval(expr, data)
+}

--- a/R/hybrid.R
+++ b/R/hybrid.R
@@ -7,30 +7,33 @@ verify_not_hybrid <- function(x) {
 }
 
 with_hybrid <- function(expr, ...) {
-  with_hybrid_(substitute(expr), ...)
+  with_hybrid_(lazyeval::f_capture(expr), ...)
 }
 
 with_hybrid_ <- function(expr, ...) {
-  expr <- eval(call("~", call("verify_hybrid", expr)))
+  stopifnot(any(class(expr) == "formula"))
+  expr[[2]] <- call("verify_hybrid", expr[[2]])
   data <- data_frame(...)
   summarise_(data, out = expr)["out"][[1]]
 }
 
 without_hybrid <- function(expr, ...) {
-  without_hybrid_(substitute(expr), ...)
+  .dots <- lazyeval::lazy_dots(out = expr)[[1]]
+  without_hybrid_(lazyeval::f_new(.dots$expr, env = .dots$env), ...)
 }
 
 without_hybrid_ <- function(expr, ...) {
-  expr <- eval(call("~", call("verify_not_hybrid", expr)))
+  stopifnot(any(class(expr) == "formula"))
+  expr[[2]] <- call("verify_not_hybrid", expr[[2]])
   data <- data_frame(...)
   summarise_(data, out = expr)["out"][[1]]
 }
 
 eval_dots <- function(expr, ...) {
-  eval_dots_(substitute(expr), ...)
+  eval_dots_(lazyeval::f_capture(expr), ...)
 }
 
 eval_dots_ <- function(expr, ...) {
   data <- data_frame(...)
-  eval(expr, data)
+  eval(expr[[2]], data, enclos = environment(expr))
 }

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -44,7 +44,7 @@ nth <- function(x, n, order_by = NULL, default = default_missing(x)) {
 
   # Negative values index from RHS
   if (n < 0) {
-    n <- length(x) + n + 1L
+    n <- length(x) + n + 1
   }
 
   if (is.null(order_by)) {

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -35,18 +35,22 @@ nth <- function(x, n, order_by = NULL, default = default_missing(x)) {
   n <- trunc(n)
 
   if (n == 0 || n > length(x) || n < -length(x)) {
-    return(default)
+    if (is.list(x)) {
+      return(default)
+    } else {
+      return(as.vector(default, class(x)))
+    }
   }
 
   # Negative values index from RHS
   if (n < 0) {
-    n <- length(x) + n + 1
+    n <- length(x) + n + 1L
   }
 
   if (is.null(order_by)) {
     x[[n]]
   } else {
-    x[[order(order_by)[n]]]
+    x[[ order(order_by)[[n]] ]]
   }
 }
 

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -38,7 +38,7 @@ nth <- function(x, n, order_by = NULL, default = default_missing(x)) {
     if (is.list(x)) {
       return(default)
     } else {
-      return(as.vector(default, class(x)))
+      return(as.vector(default, typeof(x)))
     }
   }
 

--- a/R/rank.R
+++ b/R/rank.R
@@ -51,7 +51,7 @@ row_number <- function(x) rank(x, ties.method = "first", na.last = "keep")
 #' @export
 #' @rdname ranking
 ntile <- function(x, n) {
-  floor((n * (row_number(x) - 1) / length(x)) + 1)
+  as.integer(floor((n * (row_number(x) - 1) / length(x)) + 1))
 }
 
 #' @export

--- a/R/utils.r
+++ b/R/utils.r
@@ -172,19 +172,3 @@ is_1d <- function(x) {
 }
 
 is_bare_list <- function(x) is.list(x) && !is.object(x)
-
-# Returns the value of x if it is a constant, otherwise returns NULL
-# The compile() call with the optimize = 3 option performs constant folding
-# (among other things), it also processes calls like c(), list(), :, and [[.
-# It returns byte code, which then needs to be evaluated.  If evaluation in
-# a new empty environment succeeds, the result is a constant and can be returned.
-# Simply calling eval(x, emptyenv()) won't find c() et al.
-constfold <- function(x) {
-  tryCatch(
-    {
-      compiled <- compiler::compile(x, options = list(optimize = 3, suppressAll = TRUE))
-      eval(compiled, new.env(parent = emptyenv()))
-    },
-    error = function(e) NULL
-  )
-}

--- a/R/utils.r
+++ b/R/utils.r
@@ -179,6 +179,6 @@ constfold <- function(x) {
       compiled <- compiler::compile(x, options = list(optimize = 3, suppressAll = TRUE))
       eval(compiled, new.env(parent = emptyenv()))
     },
-    error = function(e) x
+    error = function(e) NULL
   )
 }

--- a/R/utils.r
+++ b/R/utils.r
@@ -173,6 +173,12 @@ is_1d <- function(x) {
 
 is_bare_list <- function(x) is.list(x) && !is.object(x)
 
+# Returns the value of x if it is a constant, otherwise returns NULL
+# The compile() call with the optimize = 3 option performs constant folding
+# (among other things), it also processes calls like c(), list(), :, and [[.
+# It returns byte code, which then needs to be evaluated.  If evaluation in
+# a new empty environment succeeds, the result is a constant and can be returned.
+# Simply calling eval(x, emptyenv()) won't find c() et al.
 constfold <- function(x) {
   tryCatch(
     {

--- a/R/utils.r
+++ b/R/utils.r
@@ -172,3 +172,13 @@ is_1d <- function(x) {
 }
 
 is_bare_list <- function(x) is.list(x) && !is.object(x)
+
+constfold <- function(x) {
+  tryCatch(
+    {
+      compiled <- compiler::compile(x, options = list(optimize = 3, suppressAll = TRUE))
+      eval(compiled, new.env(parent = emptyenv()))
+    },
+    error = function(e) x
+  )
+}

--- a/inst/include/dplyr/HybridHandlerMap.h
+++ b/inst/include/dplyr/HybridHandlerMap.h
@@ -13,6 +13,7 @@ void install_nth_handlers(HybridHandlerMap& handlers);
 void install_window_handlers(HybridHandlerMap& handlers);
 void install_offset_handlers(HybridHandlerMap& handlers);
 void install_in_handlers(HybridHandlerMap& handlers);
+void install_debug_handlers(HybridHandlerMap& handlers);
 
 bool hybridable(RObject arg);
 

--- a/inst/include/dplyr/Result/Sd.h
+++ b/inst/include/dplyr/Result/Sd.h
@@ -17,7 +17,10 @@ namespace dplyr {
     ~Sd() {}
 
     inline double process_chunk(const SlicingIndex& indices) {
-      return sqrt(var.process_chunk(indices));
+      double var_result = var.process_chunk(indices);
+      if (NumericVector::is_na(var_result))
+        return var_result;
+      return ::sqrt(var_result);
     }
 
   private:

--- a/inst/include/tools/constfold.h
+++ b/inst/include/tools/constfold.h
@@ -17,7 +17,11 @@ namespace dplyr {
 
   inline SEXP r_constfold(SEXP x) {
     static RConstFold constfold;
-    return constfold(x);
+    SEXP ret = constfold(x);
+    if (Rf_isNull(ret))
+      return x;
+
+    return ret;
   }
 
 }

--- a/inst/include/tools/constfold.h
+++ b/inst/include/tools/constfold.h
@@ -5,12 +5,17 @@
 namespace dplyr {
 
   inline SEXP r_constfold(SEXP x) {
-    static Function constfold("constfold", "dplyr");
-    SEXP ret = constfold(x);
-    if (Rf_isNull(ret))
+    if (!Rf_isLanguage(x)) {
       return x;
+    }
 
-    return ret;
+    static Function force("force", R_BaseEnv);
+    try {
+      return force(x);
+    }
+    catch (...) {
+      return x;
+    }
   }
 
 }

--- a/inst/include/tools/constfold.h
+++ b/inst/include/tools/constfold.h
@@ -1,0 +1,25 @@
+#ifndef dplyr_tools_constfold_h
+#define dplyr_tools_constfold_h
+
+
+namespace dplyr {
+
+  class RConstFold {
+  public:
+    RConstFold() : constfold_fun("constfold", Environment::namespace_env("dplyr")) {}
+    SEXP operator()(SEXP x) {
+      return constfold_fun(x);
+    }
+
+  private:
+    Function constfold_fun;
+  };
+
+  inline SEXP r_constfold(SEXP x) {
+    static RConstFold constfold;
+    return constfold(x);
+  }
+
+}
+
+#endif

--- a/inst/include/tools/constfold.h
+++ b/inst/include/tools/constfold.h
@@ -4,19 +4,8 @@
 
 namespace dplyr {
 
-  class RConstFold {
-  public:
-    RConstFold() : constfold_fun("constfold", Environment::namespace_env("dplyr")) {}
-    SEXP operator()(SEXP x) {
-      return constfold_fun(x);
-    }
-
-  private:
-    Function constfold_fun;
-  };
-
   inline SEXP r_constfold(SEXP x) {
-    static RConstFold constfold;
+    static Function constfold("constfold", "dplyr");
     SEXP ret = constfold(x);
     if (Rf_isNull(ret))
       return x;

--- a/inst/include/tools/match.h
+++ b/inst/include/tools/match.h
@@ -20,6 +20,22 @@ namespace dplyr {
     return m(x, y);
   }
 
+  class RMatchCall {
+  public:
+    RMatchCall() : match_call_fun("match.call", R_BaseEnv) {}
+    //RMatchCall() : match_call_fun("match_call", Environment::namespace_env("dplyr")) {}
+    SEXP operator()(SEXP definition, SEXP call) {
+      return match_call_fun(definition, call);
+    }
+
+    Function match_call_fun;
+  };
+
+  inline SEXP r_match_call(SEXP definition, SEXP call) {
+    static RMatchCall m;
+    return m(definition, Rf_lang2(R_QuoteSymbol, call));
+  }
+
 }
 
 #endif

--- a/inst/include/tools/match.h
+++ b/inst/include/tools/match.h
@@ -4,36 +4,14 @@
 
 namespace dplyr {
 
-  class RMatch {
-  public:
-    RMatch() : match_fun("match", R_BaseEnv) {}
-    IntegerVector operator()(SEXP x, SEXP y) {
-      return match_fun(x, y, NA_INTEGER, CharacterVector());
-    }
-
-  private:
-    Function match_fun;
-  };
-
   inline IntegerVector r_match(SEXP x, SEXP y) {
-    static RMatch m;
-    return m(x, y);
+    static Function match("match", R_BaseEnv);
+    return match(x, y, NA_INTEGER, CharacterVector());
   }
 
-  class RMatchCall {
-  public:
-    RMatchCall() : match_call_fun("match.call", R_BaseEnv) {}
-    //RMatchCall() : match_call_fun("match_call", Environment::namespace_env("dplyr")) {}
-    SEXP operator()(SEXP definition, SEXP call) {
-      return match_call_fun(definition, call);
-    }
-
-    Function match_call_fun;
-  };
-
   inline SEXP r_match_call(SEXP definition, SEXP call) {
-    static RMatchCall m;
-    return m(definition, Rf_lang2(R_QuoteSymbol, call));
+    static Function match_call("match.call", R_BaseEnv);
+    return match_call(definition, Rf_lang2(R_QuoteSymbol, call));
   }
 
 }

--- a/inst/include/tools/na_rm.h
+++ b/inst/include/tools/na_rm.h
@@ -1,0 +1,35 @@
+#ifndef dplyr_tools_na_rm_h
+#define dplyr_tools_na_rm_h
+
+namespace dplyr {
+
+  enum NaRmResult {
+    WRONG_TAG = 0,
+    INVALID = 1,
+    NA_RM_FALSE = 2,
+    NA_RM_TRUE = 3
+  };
+
+  inline NaRmResult eval_na_rm(SEXP x) {
+    if (TAG(x) != R_NaRmSymbol)
+      return WRONG_TAG;
+
+    SEXP narme = CAR(x);
+    SEXP narm = r_constfold(narme);
+    if (TYPEOF(narm) != LGLSXP)
+      return INVALID;
+    if (LENGTH(narm) != 1)
+      return INVALID;
+
+    if (LOGICAL(narm)[0] == TRUE)
+      return NA_RM_TRUE;
+
+    if (LOGICAL(narm)[0] == FALSE)
+      return NA_RM_FALSE;
+
+    return INVALID;
+  }
+
+}
+
+#endif // dplyr_tools_na_rm_h

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -136,7 +136,6 @@ namespace dplyr {
         if (Rf_length(data) == 1) return constant_handler(data);
       }
     } else {
-      // TODO: perhaps deal with SYMSXP separately
       if (Rf_length(call) == 1) return constant_handler(call);
     }
     return 0;

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -76,6 +76,7 @@ HybridHandlerMap& get_handlers() {
     install_window_handlers(handlers);
     install_offset_handlers(handlers);
     install_in_handlers(handlers);
+    install_debug_handlers(handlers);
   }
   return handlers;
 }

--- a/src/hybrid_count.cpp
+++ b/src/hybrid_count.cpp
@@ -10,6 +10,7 @@
 #include <dplyr/Result/Count_Distinct.h>
 
 #include <tools/constfold.h>
+#include <tools/match.h>
 
 using namespace Rcpp;
 using namespace dplyr;
@@ -20,9 +21,16 @@ Result* count_prototype(SEXP args, const ILazySubsets&, int) {
   return new Count;
 }
 
+SEXP get_n_distinct() {
+  static Function n_distinct("n_distinct", Environment::namespace_env("dplyr"));
+  return n_distinct;
+}
+
 Result* count_distinct_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   MultipleVectorVisitors visitors;
   bool na_rm = false;
+
+  call = r_match_call(get_n_distinct(), call);
 
   for (SEXP p = CDR(call); !Rf_isNull(p); p = CDR(p)) {
     SEXP xe = CAR(p);

--- a/src/hybrid_count.cpp
+++ b/src/hybrid_count.cpp
@@ -9,6 +9,8 @@
 #include <dplyr/Result/Count.h>
 #include <dplyr/Result/Count_Distinct.h>
 
+#include <tools/constfold.h>
+
 using namespace Rcpp;
 using namespace dplyr;
 
@@ -23,15 +25,16 @@ Result* count_distinct_prototype(SEXP call, const ILazySubsets& subsets, int nar
   bool na_rm = false;
 
   for (SEXP p = CDR(call); !Rf_isNull(p); p = CDR(p)) {
-    SEXP x = CAR(p);
-    if (!Rf_isNull(TAG(p)) && TAG(p) == Rf_install("na.rm")) {
+    SEXP xe = CAR(p);
+    if (!Rf_isNull(TAG(p)) && TAG(p) == R_NaRmSymbol) {
+      SEXP x = r_constfold(xe);
       if (TYPEOF(x) == LGLSXP && Rf_length(x) == 1) {
         na_rm = LOGICAL(x)[0];
       } else {
         stop("incompatible value for `na.rm` parameter");
       }
-    } else if (TYPEOF(x) == SYMSXP) {
-      visitors.push_back(subsets.get_variable(x));
+    } else if (TYPEOF(xe) == SYMSXP) {
+      visitors.push_back(subsets.get_variable(xe));
     } else {
       return 0;
     }

--- a/src/hybrid_count.cpp
+++ b/src/hybrid_count.cpp
@@ -36,8 +36,8 @@ Result* count_distinct_prototype(SEXP call, const ILazySubsets& subsets, int nar
     SEXP xe = CAR(p);
     if (!Rf_isNull(TAG(p)) && TAG(p) == R_NaRmSymbol) {
       SEXP x = r_constfold(xe);
-      if (TYPEOF(x) == LGLSXP && Rf_length(x) == 1) {
-        na_rm = LOGICAL(x)[0];
+      if (is<bool>(x)) {
+        na_rm = as<bool>(x);
       } else {
         stop("incompatible value for `na.rm` parameter");
       }

--- a/src/hybrid_count.cpp
+++ b/src/hybrid_count.cpp
@@ -39,9 +39,14 @@ Result* count_distinct_prototype(SEXP call, const ILazySubsets& subsets, int nar
       if (is<bool>(x)) {
         na_rm = as<bool>(x);
       } else {
-        stop("incompatible value for `na.rm` parameter");
+        LOG_VERBOSE;
+        return 0;
       }
     } else if (TYPEOF(xe) == SYMSXP) {
+      if (!subsets.count(xe)) {
+        LOG_VERBOSE;
+        return 0;
+      }
       visitors.push_back(subsets.get_variable(xe));
     } else {
       return 0;
@@ -49,7 +54,8 @@ Result* count_distinct_prototype(SEXP call, const ILazySubsets& subsets, int nar
   }
 
   if (visitors.size() == 0) {
-    stop("need at least one column for n_distinct()");
+    LOG_VERBOSE;
+    return 0;
   }
 
   if (na_rm) {

--- a/src/hybrid_debug.cpp
+++ b/src/hybrid_debug.cpp
@@ -1,0 +1,92 @@
+#include <dplyr/main.h>
+
+#include <dplyr/HybridHandlerMap.h>
+
+#include <dplyr/Result/ILazySubsets.h>
+
+#include <dplyr/Result/Result.h>
+
+using namespace Rcpp;
+using namespace dplyr;
+
+
+class VerifyHybrid : public Result {
+public:
+  VerifyHybrid(SEXP x_) : x(x_) {}
+
+public:
+  SEXP process(const RowwiseDataFrame&) {
+    return x;
+  }
+
+  SEXP process(const GroupedDataFrame&) {
+    return x;
+  }
+
+  SEXP process(const FullDataFrame&) {
+    return x;
+  }
+
+  SEXP process(const SlicingIndex&) {
+    return x;
+  }
+
+private:
+  RObject x;
+};
+
+Result* verify_hybrid_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
+  // if not exactly one arg, let R handle it
+  if (nargs != 1)
+    return 0;
+
+  // if it isn't a constant, let R handle it
+  SEXP arg = CADR(call);
+  if (TYPEOF(arg) == SYMSXP || TYPEOF(arg) == LANGSXP)
+    return 0;
+
+  return new VerifyHybrid(arg);
+}
+
+class VerifyNotHybrid : public Result {
+public:
+  VerifyNotHybrid(SEXP x_) : x(x_) {}
+
+public:
+  SEXP process(const RowwiseDataFrame&) {
+    stop("In hybrid evaluation");
+  }
+
+  SEXP process(const GroupedDataFrame&) {
+    stop("In hybrid evaluation");
+  }
+
+  SEXP process(const FullDataFrame&) {
+    stop("In hybrid evaluation");
+  }
+
+  SEXP process(const SlicingIndex&) {
+    stop("In hybrid evaluation");
+  }
+
+private:
+  RObject x;
+};
+
+Result* verify_not_hybrid_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
+  // if not exactly one arg, let R handle it
+  if (nargs != 1)
+    return 0;
+
+  // if it isn't a constant, let R handle it
+  SEXP arg = CADR(call);
+  if (TYPEOF(arg) == SYMSXP || TYPEOF(arg) == LANGSXP)
+    return 0;
+
+  return new VerifyNotHybrid(arg);
+}
+
+void install_debug_handlers(HybridHandlerMap& handlers) {
+  handlers[ Rf_install("verify_hybrid") ] = verify_hybrid_prototype;
+  handlers[ Rf_install("verify_not_hybrid") ] = verify_not_hybrid_prototype;
+}

--- a/src/hybrid_in.cpp
+++ b/src/hybrid_in.cpp
@@ -37,8 +37,6 @@ Result* in_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     return new In<INTSXP>(v, rhs);
   case REALSXP:
     return new In<REALSXP>(v, rhs);
-  case CPLXSXP:
-    return new In<CPLXSXP>(v, rhs);
   case STRSXP:
     return new In<STRSXP>(v, rhs);
   default:

--- a/src/hybrid_in.cpp
+++ b/src/hybrid_in.cpp
@@ -37,6 +37,8 @@ Result* in_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     return new In<INTSXP>(v, rhs);
   case REALSXP:
     return new In<REALSXP>(v, rhs);
+  case CPLXSXP:
+    return new In<CPLXSXP>(v, rhs);
   case STRSXP:
     return new In<STRSXP>(v, rhs);
   default:

--- a/src/hybrid_in.cpp
+++ b/src/hybrid_in.cpp
@@ -6,12 +6,14 @@
 
 #include <dplyr/Result/In.h>
 
+#include <tools/constfold.h>
+
 using namespace Rcpp;
 using namespace dplyr;
 
 Result* in_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   SEXP lhs = CADR(call);
-  SEXP rhs = CADDR(call);
+  SEXP rhse = CADDR(call);
 
   // if lhs is not a symbol, let R handle it
   if (TYPEOF(lhs) != SYMSXP) return 0;
@@ -21,8 +23,10 @@ Result* in_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 
   SEXP v = subsets.get_variable(lhs);
 
-  // if the type of the data is not the same as the type of rhs,
-  // including if it needs evaluation, let R handle it
+  SEXP rhs = r_constfold(rhse);
+
+  // if the type of the data is not the same as the type of rhs (after constant folding),
+  // including if it still needs evaluation, let R handle it
   if (TYPEOF(v) != TYPEOF(rhs)) return 0;
 
   // otherwise use hybrid version

--- a/src/hybrid_minmax.cpp
+++ b/src/hybrid_minmax.cpp
@@ -8,6 +8,7 @@
 #include <dplyr/Result/Max.h>
 
 #include <tools/constfold.h>
+#include <tools/match.h>
 
 using namespace Rcpp;
 using namespace dplyr;
@@ -27,11 +28,18 @@ Result* minmax_prototype_impl(SEXP arg, bool is_summary) {
   return 0;
 }
 
+SEXP get_min() {
+  // min() is a primitive, but pmin() effectively has the same interface
+  static Function min_("pmin", R_BaseEnv);
+  return min_;
+}
+
 template< template <int, bool> class Tmpl>
 Result* minmax_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
-  using namespace dplyr;
   // we only can handle 1 or two arguments
   if (nargs == 0 || nargs > 2) return 0;
+
+  call = r_match_call(get_min(), call);
 
   // the first argument is the data to operate on
   SEXP arg = CADR(call);

--- a/src/hybrid_minmax.cpp
+++ b/src/hybrid_minmax.cpp
@@ -7,6 +7,8 @@
 #include <dplyr/Result/Min.h>
 #include <dplyr/Result/Max.h>
 
+#include <tools/constfold.h>
+
 using namespace Rcpp;
 using namespace dplyr;
 
@@ -51,12 +53,13 @@ Result* minmax_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     SEXP arg2 = CDDR(call);
     // we know how to handle fun( ., na.rm = TRUE/FALSE )
     if (TAG(arg2) == R_NaRmSymbol) {
-      SEXP narm = CAR(arg2);
+      SEXP narme = CAR(arg2);
+      SEXP narm = r_constfold(narme);
       if (TYPEOF(narm) == LGLSXP && LENGTH(narm) == 1) {
         if (LOGICAL(narm)[0] == TRUE) {
-          return minmax_prototype_impl<Tmpl,true>(arg, is_summary);
+          return minmax_prototype_impl<Tmpl, true>(arg, is_summary);
         } else {
-          return minmax_prototype_impl<Tmpl,false>(arg, is_summary);
+          return minmax_prototype_impl<Tmpl, false>(arg, is_summary);
         }
       }
     }

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -7,6 +7,8 @@
 #include <dplyr/Result/ILazySubsets.h>
 #include <dplyr/Result/VectorSliceVisitor.h>
 
+#include <tools/constfold.h>
+
 using namespace Rcpp;
 using namespace dplyr;
 
@@ -144,7 +146,8 @@ namespace dplyr {
     if (tag != R_NilValue && tag != Rf_install("n")) {
       stop("the second argument of 'first' should be either 'n' or unnamed");
     }
-    SEXP nidx = CADDR(call);
+    SEXP nidxe = CADDR(call);
+    SEXP nidx = r_constfold(nidxe);
     if ((TYPEOF(nidx) != REALSXP && TYPEOF(nidx) != INTSXP) || LENGTH(nidx) != 1) {
       // we only know how to handle the case where nidx is a length one
       // integer or numeric. In any other case, e.g. an expression for R to evaluate

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -202,12 +202,11 @@ namespace dplyr {
     // integer or numeric. In any other case, e.g. an expression for R to evaluate
     // we just fallback to R evaluation (#734)
     int idx;
-    try {
-      idx = as<int>(nidx);
-    }
-    catch (...) {
+    if (!is<int>(nidx) && !is<double>(nidx)) {
+      LOG_VERBOSE;
       return 0;
     }
+    idx = as<int>(nidx);
 
     p = CDR(p);
     tag = TAG(p);

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -187,6 +187,10 @@ namespace dplyr {
       }
       data = subsets.get_variable(data);
     }
+    else {
+      LOG_VERBOSE;
+      return 0;
+    }
 
     p = CDR(p);
     tag = TAG(p);

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -108,6 +108,8 @@ namespace dplyr {
       return nth_natural_<INTSXP>(data, idx, def);
     case REALSXP:
       return nth_natural_<REALSXP>(data, idx, def);
+    case CPLXSXP:
+      return nth_natural_<CPLXSXP>(data, idx, def);
     case STRSXP:
       return nth_natural_<STRSXP>(data, idx, def);
     default:
@@ -151,6 +153,8 @@ namespace dplyr {
       return nth_ordered_<INTSXP>(data, idx, order, def);
     case REALSXP:
       return nth_ordered_<REALSXP>(data, idx, order, def);
+    case CPLXSXP:
+      return nth_ordered_<CPLXSXP>(data, idx, order, def);
     case STRSXP:
       return nth_ordered_<STRSXP>(data, idx, order, def);
     default:

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -207,7 +207,7 @@ namespace dplyr {
     SEXP nidxe = CAR(p);
     SEXP nidx = r_constfold(nidxe);
     // we only know how to handle the case where nidx is a length one
-    // integer or numeric. In any other case, e.g. an expression for R to evaluate
+    // integer or numeric (after constant folding). In any other case
     // we just fallback to R evaluation (#734)
     int idx;
     if (!is<int>(nidx) && !is<double>(nidx)) {

--- a/src/hybrid_offset.cpp
+++ b/src/hybrid_offset.cpp
@@ -32,12 +32,12 @@ struct LeadLag {
     if (tag == Rf_install("n")) {
       SEXP n_e = CAR(p);
       SEXP n_ = r_constfold(n_e);
-      try {
-        n = as<int>(n_);
-      } catch (...) {
+
+      if (!is<int>(n_) && !is<double>(n_)) {
         LOG_VERBOSE;
         return;
       }
+      n = as<int>(n_);
 
       p = CDR(p);
       tag = TAG(p);

--- a/src/hybrid_simple.cpp
+++ b/src/hybrid_simple.cpp
@@ -10,6 +10,7 @@
 #include <dplyr/Result/Sd.h>
 
 #include <tools/constfold.h>
+#include <tools/match.h>
 
 using namespace Rcpp;
 using namespace dplyr;
@@ -30,9 +31,21 @@ Result* simple_prototype_impl(SEXP arg, bool is_summary) {
   return 0;
 }
 
+SEXP get_simple_fun() {
+  // pmin() has a suitable interface
+  static Function pmin("pmin", R_BaseEnv);
+  return pmin;
+}
+
 template <template <int,bool> class Fun>
 Result* simple_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
-  if (nargs == 0) return 0;
+  if (nargs == 0 || nargs > 2) {
+    LOG_VERBOSE;
+    return 0;
+  }
+
+  call = r_match_call(get_simple_fun(), call);
+
   SEXP arg = CADR(call);
   bool is_summary = false;
   if (TYPEOF(arg) == SYMSXP) {

--- a/src/hybrid_simple.cpp
+++ b/src/hybrid_simple.cpp
@@ -9,6 +9,8 @@
 #include <dplyr/Result/Var.h>
 #include <dplyr/Result/Sd.h>
 
+#include <tools/constfold.h>
+
 using namespace Rcpp;
 using namespace dplyr;
 
@@ -55,7 +57,8 @@ Result* simple_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     SEXP arg2 = CDDR(call);
     // we know how to handle fun( ., na.rm = TRUE/FALSE )
     if (TAG(arg2) == R_NaRmSymbol) {
-      SEXP narm = CAR(arg2);
+      SEXP narme = CAR(arg2);
+      SEXP narm = r_constfold(narme);
       if (TYPEOF(narm) == LGLSXP && LENGTH(narm) == 1) {
         if (LOGICAL(narm)[0] == TRUE) {
           return simple_prototype_impl<Fun, true>(arg, is_summary);

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -4,6 +4,7 @@
 
 #include <dplyr/Result/ILazySubsets.h>
 #include <dplyr/Result/Rank.h>
+#include <tools/constfold.h>
 
 using namespace Rcpp;
 using namespace dplyr;
@@ -59,12 +60,14 @@ Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   if (nargs != 2) return 0;
 
   // handle 2nd arg
-  SEXP ntiles = CADDR(call);
+  SEXP ntilese = CADDR(call);
+  SEXP ntiles = r_constfold(ntilese);
   double number_tiles;
   try {
     number_tiles = as<int>(ntiles);
   } catch (...) {
-    stop("could not convert n to scalar integer");
+    LOG_VERBOSE;
+    return 0;
   }
 
   RObject data(CADR(call));

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -5,6 +5,7 @@
 #include <dplyr/Result/ILazySubsets.h>
 #include <dplyr/Result/Rank.h>
 #include <tools/constfold.h>
+#include <tools/match.h>
 
 using namespace Rcpp;
 using namespace dplyr;
@@ -56,8 +57,15 @@ Result* row_number_prototype(SEXP call, const ILazySubsets& subsets, int nargs) 
   return 0;
 }
 
+SEXP get_ntile() {
+  static Function ntile("ntile", Environment::namespace_env("dplyr"));
+  return ntile;
+}
+
 Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   if (nargs != 2) return 0;
+
+  call = r_match_call(get_ntile(), call);
 
   // handle 2nd arg
   SEXP ntilese = CADDR(call);

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -71,12 +71,11 @@ Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   SEXP ntilese = CADDR(call);
   SEXP ntiles = r_constfold(ntilese);
   double number_tiles;
-  try {
-    number_tiles = as<int>(ntiles);
-  } catch (...) {
+  if (!is<int>(ntiles) && !is<double>(ntiles)) {
     LOG_VERBOSE;
     return 0;
   }
+  number_tiles = as<double>(ntiles);
 
   RObject data(CADR(call));
   if (TYPEOF(data) == LANGSXP && CAR(data) == Rf_install("desc")) {

--- a/tests/testthat/helper-hybrid.R
+++ b/tests/testthat/helper-hybrid.R
@@ -1,19 +1,19 @@
-expect_hybrid <- function(expr, ..., expected, test_eval = TRUE) {
-  expect_hybrid_(lazyeval::f_capture(expr), ..., expected = expected, test_eval = test_eval)
+check_hybrid_result <- function(expr, ..., expected, test_eval = TRUE) {
+  check_hybrid_result_(lazyeval::f_capture(expr), ..., expected = expected, test_eval = test_eval)
 }
 
-expect_hybrid_ <- function(expr, ..., expected, test_eval) {
+check_hybrid_result_ <- function(expr, ..., expected, test_eval) {
   expect_identical(with_hybrid_(expr, ...), expected)
   if (test_eval) {
     expect_identical(eval_dots_(expr, ...), expected)
   }
 }
 
-expect_not_hybrid <- function(expr, ..., expected, test_eval = TRUE) {
-  expect_not_hybrid_(lazyeval::f_capture(expr), ..., expected = expected, test_eval = test_eval)
+check_not_hybrid_result <- function(expr, ..., expected, test_eval = TRUE) {
+  check_not_hybrid_result_(lazyeval::f_capture(expr), ..., expected = expected, test_eval = test_eval)
 }
 
-expect_not_hybrid_ <- function(expr, ..., expected, test_eval) {
+check_not_hybrid_result_ <- function(expr, ..., expected, test_eval) {
   expect_identical(without_hybrid_(expr, ...), expected)
   if (test_eval) {
     expect_identical(eval_dots_(expr, ...), expected)

--- a/tests/testthat/helper-hybrid.R
+++ b/tests/testthat/helper-hybrid.R
@@ -1,5 +1,5 @@
 expect_hybrid <- function(expr, ..., expected, test_eval = TRUE) {
-  expect_hybrid_(substitute(expr), ..., expected = expected, test_eval = test_eval)
+  expect_hybrid_(lazyeval::f_capture(expr), ..., expected = expected, test_eval = test_eval)
 }
 
 expect_hybrid_ <- function(expr, ..., expected, test_eval) {
@@ -10,7 +10,7 @@ expect_hybrid_ <- function(expr, ..., expected, test_eval) {
 }
 
 expect_not_hybrid <- function(expr, ..., expected, test_eval = TRUE) {
-  expect_not_hybrid_(substitute(expr), ..., expected = expected, test_eval = test_eval)
+  expect_not_hybrid_(lazyeval::f_capture(expr), ..., expected = expected, test_eval = test_eval)
 }
 
 expect_not_hybrid_ <- function(expr, ..., expected, test_eval) {
@@ -21,7 +21,7 @@ expect_not_hybrid_ <- function(expr, ..., expected, test_eval) {
 }
 
 expect_hybrid_error <- function(expr, ..., error) {
-  expect_hybrid_error_(substitute(expr), ..., error = error)
+  expect_hybrid_error_(lazyeval::f_capture(expr), ..., error = error)
 }
 
 expect_hybrid_error_ <- function(expr, ..., error) {
@@ -31,7 +31,7 @@ expect_hybrid_error_ <- function(expr, ..., error) {
 }
 
 expect_not_hybrid_error <- function(expr, ..., error) {
-  expect_not_hybrid_error_(substitute(expr), ..., error = error)
+  expect_not_hybrid_error_(lazyeval::f_capture(expr), ..., error = error)
 }
 
 expect_not_hybrid_error_ <- function(expr, ..., error) {

--- a/tests/testthat/helper-hybrid.R
+++ b/tests/testthat/helper-hybrid.R
@@ -1,0 +1,41 @@
+expect_hybrid <- function(expr, ..., expected, test_eval = TRUE) {
+  expect_hybrid_(substitute(expr), ..., expected = expected, test_eval = test_eval)
+}
+
+expect_hybrid_ <- function(expr, ..., expected, test_eval) {
+  expect_identical(with_hybrid_(expr, ...), expected)
+  if (test_eval) {
+    expect_identical(eval_dots_(expr, ...), expected)
+  }
+}
+
+expect_not_hybrid <- function(expr, ..., expected, test_eval = TRUE) {
+  expect_not_hybrid_(substitute(expr), ..., expected = expected, test_eval = test_eval)
+}
+
+expect_not_hybrid_ <- function(expr, ..., expected, test_eval) {
+  expect_identical(without_hybrid_(expr, ...), expected)
+  if (test_eval) {
+    expect_identical(eval_dots_(expr, ...), expected)
+  }
+}
+
+expect_hybrid_error <- function(expr, ..., error) {
+  expect_hybrid_error_(substitute(expr), ..., error = error)
+}
+
+expect_hybrid_error_ <- function(expr, ..., error) {
+  expect_error(
+    with_hybrid_(expr, ...),
+    error)
+}
+
+expect_not_hybrid_error <- function(expr, ..., error) {
+  expect_not_hybrid_error_(substitute(expr), ..., error = error)
+}
+
+expect_not_hybrid_error_ <- function(expr, ..., error) {
+  expect_error(
+    without_hybrid_(expr, ...),
+    error)
+}

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -597,3 +597,19 @@ test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and 
     error = "unused argument"
   )
 })
+
+test_that("hybrid handlers don't nest", {
+  check_not_hybrid_result(
+    mean(lag(a)), a = 1:5,
+    expected = NA_real_
+  )
+  check_not_hybrid_result(
+    mean(row_number()), a = 1:5,
+    expected = 3,
+    test_eval = FALSE
+  )
+  check_not_hybrid_result(
+    list(lag(cume_dist(a))), a = 1:4,
+    expected = list(c(NA, 0.25, 0.5, 0.75))
+  )
+})

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -90,13 +90,23 @@ test_that("first(), last(), and nth() work", {
                 expected = 5)
   expect_hybrid(nth(a, 1 + 2), a = letters[1:5],
                 expected = "c")
-  expect_hybrid(nth(a, 6), a = as.numeric(1:5),
-                expected = NA_real_)
+  expect_hybrid(nth(a, 6, default = 3L), a = as.numeric(1:5),
+                expected = 3)
   expect_hybrid(nth(a, 6.5), a = 1:5,
                 expected = NA_integer_)
+  expect_hybrid(nth(a, -4), a = 1:5,
+                expected = 2L)
 
   expect_not_hybrid(nth(a, b[[2]]), a = letters[1:5], b = 5:1,
                     expected = "d")
+  expect_not_hybrid(nth(a, 2), a = as.list(1:5),
+                    expected = 2L)
+
+  skip("Currently failing")
+  expect_hybrid(nth(a, order_by = 5:1, 2), a = 1:5,
+                expected = 4L)
+  expect_hybrid(first(a, order_by = b), a = 1:5, b = 5:1,
+                expected = 5L)
 })
 
 test_that("lead() and lag() work", {

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -150,3 +150,52 @@ test_that("lead() and lag() work", {
   expect_not_hybrid(list(lag(a, order_by = b)), a = 1:5, b = 5:1,
                     expected = list(c(2:5, NA)))
 })
+
+test_that("mean(), var(), sd() and sum() work", {
+  expect_hybrid(mean(a), a = 1:5,
+                expected = 3)
+  expect_hybrid(var(a), a = 1:3,
+                expected = 1)
+  expect_hybrid(sd(a), a = 1:3,
+                expected = 1)
+  expect_hybrid(sum(a), a = 1:5,
+                expected = 15L)
+  expect_hybrid(sum(a), a = as.numeric(1:5),
+                expected = 15)
+
+  expect_hybrid(mean(a), a = c(1:5, NA),
+                expected = NA_real_)
+  expect_hybrid(var(a), a = c(1:3, NA),
+                expected = NA_real_)
+  expect_hybrid(sd(a), a = c(1:3, NA),
+                expected = NA_real_)
+  expect_hybrid(sum(a), a = c(1:5, NA),
+                expected = NA_integer_)
+  expect_hybrid(sum(a), a = c(as.numeric(1:5), NA),
+                expected = NA_real_)
+
+  expect_hybrid(mean(a, na.rm = (1 == 0)), a = c(1:5, NA),
+                expected = NA_real_)
+  expect_hybrid(var(a, na.rm = (1 == 0)), a = c(1:3, NA),
+                expected = NA_real_)
+  expect_hybrid(sd(a, na.rm = (1 == 0)), a = c(1:3, NA),
+                expected = NA_real_)
+  expect_hybrid(sum(a, na.rm = (1 == 0)), a = c(1:5, NA),
+                expected = NA_integer_)
+  expect_hybrid(sum(a, na.rm = (1 == 0)), a = c(as.numeric(1:5), NA),
+                expected = NA_real_)
+
+  expect_hybrid(mean(a, na.rm = (1 == 1)), a = c(1:5, NA),
+                expected = 3)
+  expect_hybrid(var(a, na.rm = (1 == 1)), a = c(1:3, NA),
+                expected = 1)
+  expect_hybrid(sd(a, na.rm = (1 == 1)), a = c(1:3, NA),
+                expected = 1)
+  expect_hybrid(sum(a, na.rm = (1 == 1)), a = c(1:5, NA),
+                expected = 15L)
+  expect_hybrid(sum(a, na.rm = (1 == 1)), a = c(as.numeric(1:5), NA),
+                expected = 15)
+
+  expect_not_hybrid(sd(a, TRUE), a = c(1:3, NA),
+                expected = 1)
+})

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1,311 +1,564 @@
 context("hybrid")
 
 test_that("n() and n_distinct() work", {
-  expect_hybrid(n(), a = 1:5, expected = 5L, test_eval = FALSE)
+  expect_hybrid(
+    n(), a = 1:5,
+    expected = 5L, test_eval = FALSE
+  )
 
-  expect_hybrid(n_distinct(a), a = 1:5,
-                expected = 5L)
-  expect_hybrid(n_distinct(a), a = rep(1L, 3),
-                expected = 1L)
-  expect_hybrid(n_distinct(a, b), a = rep(1L, 3), b = 1:3,
-                expected = 3L)
-  expect_hybrid(n_distinct(a, b), a = rep(1L, 3), b = c(1, 1, 2),
-                expected = 2L)
-  expect_hybrid(n_distinct(a, b), a = rep(1L, 3), b = c(1, 1, NA),
-                expected = 2L)
-  expect_hybrid(n_distinct(a, b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
-                expected = 1L)
-  expect_hybrid(n_distinct(a = a, b = b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
-                expected = 1L)
+  expect_hybrid(
+    n_distinct(a), a = 1:5,
+    expected = 5L
+  )
+  expect_hybrid(
+    n_distinct(a), a = rep(1L, 3),
+    expected = 1L
+  )
+  expect_hybrid(
+    n_distinct(a, b), a = rep(1L, 3), b = 1:3,
+    expected = 3L
+  )
+  expect_hybrid(
+    n_distinct(a, b), a = rep(1L, 3), b = c(1, 1, 2),
+    expected = 2L
+  )
+  expect_hybrid(
+    n_distinct(a, b), a = rep(1L, 3), b = c(1, 1, NA),
+    expected = 2L
+  )
+  expect_hybrid(
+    n_distinct(a, b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
+    expected = 1L
+  )
+  expect_hybrid(
+    n_distinct(a = a, b = b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
+    expected = 1L
+  )
 
   c <- 1:3
-  expect_not_hybrid(n_distinct(c), a = 1:5,
-                    expected = 3L, test_eval = FALSE)
-  expect_not_hybrid(n_distinct(a, c), a = 1:3,
-                    expected = 3L, test_eval = FALSE)
-  expect_not_hybrid(n_distinct(a, b, na.rm = 1), a = rep(1L, 3), b = c(1, 1, NA),
-                    expected = 1L)
-  expect_not_hybrid_error(n_distinct(), a = 1:5,
-                          error = "need at least one column")
+  expect_not_hybrid(
+    n_distinct(c), a = 1:5,
+    expected = 3L, test_eval = FALSE
+  )
+  expect_not_hybrid(
+    n_distinct(a, c), a = 1:3,
+    expected = 3L, test_eval = FALSE
+  )
+  expect_not_hybrid(
+    n_distinct(a, b, na.rm = 1), a = rep(1L, 3), b = c(1, 1, NA),
+    expected = 1L
+  )
+  expect_not_hybrid_error(
+    n_distinct(), a = 1:5,
+    error = "need at least one column"
+  )
 })
 
 test_that("%in% works (#192)", {
-  expect_hybrid(list(a %in% 1:3), a = 2:4,
-                expected = list(c(TRUE, TRUE, FALSE)))
-  expect_hybrid(list(a %in% as.numeric(1:3)), a = as.numeric(2:4),
-                expected = list(c(TRUE, TRUE, FALSE)))
-  expect_hybrid(list(a %in% letters[1:3]), a = letters[2:4],
-                expected = list(c(TRUE, TRUE, FALSE)))
-  expect_hybrid(list(a %in% c(TRUE, FALSE)), a = c(TRUE, FALSE, NA),
-                expected = list(c(TRUE, TRUE, FALSE)))
+  expect_hybrid(
+    list(a %in% 1:3), a = 2:4,
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
+  expect_hybrid(
+    list(a %in% as.numeric(1:3)), a = as.numeric(2:4),
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
+  expect_hybrid(
+    list(a %in% letters[1:3]), a = letters[2:4],
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
+  expect_hybrid(
+    list(a %in% c(TRUE, FALSE)), a = c(TRUE, FALSE, NA),
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
 
   # compilation errors on Windows
   # https://ci.appveyor.com/project/hadley/dplyr/build/1.0.230
-  expect_not_hybrid(list(a %in% (1:3 * 1i)), a = 2:4 * 1i,
-                    expected = list(c(TRUE, TRUE, FALSE)))
+  expect_not_hybrid(
+    list(a %in% (1:3 * 1i)), a = 2:4 * 1i,
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
 
-  expect_not_hybrid(list(a %in% 1:3), a = as.numeric(2:4),
-                    expected = list(c(TRUE, TRUE, FALSE)))
-  expect_not_hybrid(list(a %in% as.numeric(1:3)), a = 2:4,
-                    expected = list(c(TRUE, TRUE, FALSE)))
+  expect_not_hybrid(
+    list(a %in% 1:3), a = as.numeric(2:4),
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
+  expect_not_hybrid(
+    list(a %in% as.numeric(1:3)), a = 2:4,
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
 
   c <- 2:4
-  expect_not_hybrid(list(c %in% 1:3), a = as.numeric(2:4),
-                    expected = list(c(TRUE, TRUE, FALSE)))
+  expect_not_hybrid(
+    list(c %in% 1:3), a = as.numeric(2:4),
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
 
   skip("Currently failing")
-  expect_hybrid(list(a %in% NA_integer_), a = c(2:4, NA),
-                expected = list(c(FALSE, FALSE, FALSE, TRUE)))
-  expect_hybrid(list(a %in% NA_real_), a = as.numeric(c(2:4, NA)),
-                expected = list(c(FALSE, FALSE, FALSE, TRUE)))
-  expect_hybrid(list(a %in% NA_character_), a = c(letters[2:4], NA),
-                expected = list(c(FALSE, FALSE, FALSE, TRUE)))
-  expect_hybrid(list(a %in% NA), a = c(TRUE, FALSE, NA),
-                expected = list(c(FALSE, FALSE, TRUE)))
+  expect_hybrid(
+    list(a %in% NA_integer_), a = c(2:4, NA),
+    expected = list(c(FALSE, FALSE, FALSE, TRUE))
+  )
+  expect_hybrid(
+    list(a %in% NA_real_), a = as.numeric(c(2:4, NA)),
+    expected = list(c(FALSE, FALSE, FALSE, TRUE))
+  )
+  expect_hybrid(
+    list(a %in% NA_character_), a = c(letters[2:4], NA),
+    expected = list(c(FALSE, FALSE, FALSE, TRUE))
+  )
+  expect_hybrid(
+    list(a %in% NA), a = c(TRUE, FALSE, NA),
+    expected = list(c(FALSE, FALSE, TRUE))
+  )
 })
 
 test_that("min() and max() work", {
-  expect_hybrid(min(a), a = 1:5,
-                expected = 1L)
-  expect_hybrid(max(a), a = 1:5,
-                expected = 5L)
-  expect_hybrid(min(a), a = as.numeric(1:5),
-                expected = 1)
-  expect_hybrid(max(a), a = as.numeric(1:5),
-                expected = 5)
-  expect_hybrid(min(a), a = c(1:5, NA),
-                expected = NA_integer_)
-  expect_hybrid(max(a), a = c(1:5, NA),
-                expected = NA_integer_)
-  expect_hybrid(min(a, na.rm = (1 == 0)), a = c(1:5, NA),
-                expected = NA_integer_)
-  expect_hybrid(max(a, na.rm = (1 == 0)), a = c(1:5, NA),
-                expected = NA_integer_)
-  expect_hybrid(min(a, na.rm = (1 == 1)), a = c(1:5, NA),
-                expected = 1L)
-  expect_hybrid(max(a, na.rm = (1 == 1)), a = c(1:5, NA),
-                expected = 5L)
+  expect_hybrid(
+    min(a), a = 1:5,
+    expected = 1L
+  )
+  expect_hybrid(
+    max(a), a = 1:5,
+    expected = 5L
+  )
+  expect_hybrid(
+    min(a), a = as.numeric(1:5),
+    expected = 1
+  )
+  expect_hybrid(
+    max(a), a = as.numeric(1:5),
+    expected = 5
+  )
+  expect_hybrid(
+    min(a), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  expect_hybrid(
+    max(a), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  expect_hybrid(
+    min(a, na.rm = (1 == 0)), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  expect_hybrid(
+    max(a, na.rm = (1 == 0)), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  expect_hybrid(
+    min(a, na.rm = (1 == 1)), a = c(1:5, NA),
+    expected = 1L
+  )
+  expect_hybrid(
+    max(a, na.rm = (1 == 1)), a = c(1:5, NA),
+    expected = 5L
+  )
 
   c <- 1:3
-  expect_not_hybrid(min(c), a = 1:5,
-                    expected = 1L)
-  expect_not_hybrid(max(c), a = 1:5,
-                    expected = 3L)
+  expect_not_hybrid(
+    min(c), a = 1:5,
+    expected = 1L
+  )
+  expect_not_hybrid(
+    max(c), a = 1:5,
+    expected = 3L
+  )
 
-  expect_not_hybrid(min(a), a = letters,
-                    expected = "a")
-  expect_not_hybrid(max(a), a = letters,
-                    expected = "z")
-  expect_not_hybrid(min(a), a = c(letters, NA),
-                    expected = NA_character_)
-  expect_not_hybrid(max(a), a = c(letters, NA),
-                    expected = NA_character_)
-  expect_not_hybrid(min(a, na.rm = TRUE), a = c(letters, NA),
-                    expected = "a")
-  expect_not_hybrid(max(a, na.rm = TRUE), a = c(letters, NA),
-                    expected = "z")
+  expect_not_hybrid(
+    min(a), a = letters,
+    expected = "a"
+  )
+  expect_not_hybrid(
+    max(a), a = letters,
+    expected = "z"
+  )
+  expect_not_hybrid(
+    min(a), a = c(letters, NA),
+    expected = NA_character_
+  )
+  expect_not_hybrid(
+    max(a), a = c(letters, NA),
+    expected = NA_character_
+  )
+  expect_not_hybrid(
+    min(a, na.rm = TRUE), a = c(letters, NA),
+    expected = "a"
+  )
+  expect_not_hybrid(
+    max(a, na.rm = TRUE), a = c(letters, NA),
+    expected = "z"
+  )
 })
 
 test_that("first(), last(), and nth() work", {
-  expect_hybrid(first(a), a = 1:5,
-                expected = 1L)
-  expect_hybrid(last(a), a = as.numeric(1:5),
-                expected = 5)
-  expect_hybrid(nth(a, 3), a = as.numeric(1:5) * 1i,
-                expected = 3i)
-  expect_hybrid(nth(a, 1 + 2), a = letters[1:5],
-                expected = "c")
-  expect_hybrid(nth(a, 6, default = 3L), a = as.numeric(1:5),
-                expected = 3)
-  expect_hybrid(nth(a, 6, def = 3L), a = as.numeric(1:5),
-                expected = 3)
-  expect_hybrid(nth(a, 6.5), a = 1:5,
-                expected = NA_integer_)
-  expect_hybrid(nth(a, -4), a = 1:5,
-                expected = 2L)
+  expect_hybrid(
+    first(a), a = 1:5,
+    expected = 1L
+  )
+  expect_hybrid(
+    last(a), a = as.numeric(1:5),
+    expected = 5
+  )
+  expect_hybrid(
+    nth(a, 3), a = as.numeric(1:5) * 1i,
+    expected = 3i
+  )
+  expect_hybrid(
+    nth(a, 1 + 2), a = letters[1:5],
+    expected = "c"
+  )
+  expect_hybrid(
+    nth(a, 6, default = 3L), a = as.numeric(1:5),
+    expected = 3
+  )
+  expect_hybrid(
+    nth(a, 6, def = 3L), a = as.numeric(1:5),
+    expected = 3
+  )
+  expect_hybrid(
+    nth(a, 6.5), a = 1:5,
+    expected = NA_integer_
+  )
+  expect_hybrid(
+    nth(a, -4), a = 1:5,
+    expected = 2L
+  )
 
-  expect_not_hybrid(nth(a, b[[2]]), a = letters[1:5], b = 5:1,
-                    expected = "d")
-  expect_not_hybrid(nth(a, 2), a = as.list(1:5),
-                    expected = 2L)
+  expect_not_hybrid(
+    nth(a, b[[2]]), a = letters[1:5], b = 5:1,
+    expected = "d"
+  )
+  expect_not_hybrid(
+    nth(a, 2), a = as.list(1:5),
+    expected = 2L
+  )
 
-  expect_not_hybrid(nth(a, order_by = 5:1, 2), a = 1:5,
-                    expected = 4L)
-  expect_not_hybrid(first(a, order_by = b), a = 1:5, b = 5:1,
-                    expected = 5L)
+  expect_not_hybrid(
+    nth(a, order_by = 5:1, 2), a = 1:5,
+    expected = 4L
+  )
+  expect_not_hybrid(
+    first(a, order_by = b), a = 1:5, b = 5:1,
+    expected = 5L
+  )
 
   c <- 1:3
-  expect_not_hybrid(first(c), a = 2:4,
-                    expected = 1L)
-  expect_not_hybrid(last(c), a = 2:4,
-                    expected = 3L)
-  expect_not_hybrid(nth(c, 2), a = 2:4,
-                    expected = 2L)
+  expect_not_hybrid(
+    first(c), a = 2:4,
+    expected = 1L
+  )
+  expect_not_hybrid(
+    last(c), a = 2:4,
+    expected = 3L
+  )
+  expect_not_hybrid(
+    nth(c, 2), a = 2:4,
+    expected = 2L
+  )
 
-  expect_not_hybrid_error(first(a, bogus = 3), a = 1:5,
-                          error = "unused argument")
-  expect_not_hybrid_error(last(a, bogus = 3), a = 1:5,
-                          error = "unused argument")
-  expect_not_hybrid_error(nth(a, 3, bogus = 3), a = 1:5,
-                          error = "unused argument")
+  expect_not_hybrid_error(
+    first(a, bogus = 3), a = 1:5,
+    error = "unused argument"
+  )
+  expect_not_hybrid_error(
+    last(a, bogus = 3), a = 1:5,
+    error = "unused argument"
+  )
+  expect_not_hybrid_error(
+    nth(a, 3, bogus = 3), a = 1:5,
+    error = "unused argument"
+  )
 })
 
 test_that("lead() and lag() work", {
-  expect_hybrid(list(lead(a)), a = 1:5,
-                expected = list(c(2:5, NA)))
-  expect_hybrid(list(lag(a)), a = 1:5,
-                expected = list(c(NA, 1:4)))
+  expect_hybrid(
+    list(lead(a)), a = 1:5,
+    expected = list(c(2:5, NA))
+  )
+  expect_hybrid(
+    list(lag(a)), a = 1:5,
+    expected = list(c(NA, 1:4))
+  )
 
-  expect_hybrid(list(lead(a)), a = as.numeric(1:5),
-                expected = list(c(as.numeric(2:5), NA)))
-  expect_hybrid(list(lag(a)), a = as.numeric(1:5),
-                expected = list(c(NA, as.numeric(1:4))))
+  expect_hybrid(
+    list(lead(a)), a = as.numeric(1:5),
+    expected = list(c(as.numeric(2:5), NA))
+  )
+  expect_hybrid(
+    list(lag(a)), a = as.numeric(1:5),
+    expected = list(c(NA, as.numeric(1:4)))
+  )
 
-  expect_hybrid(list(lead(a)), a = 1:5 * 1i,
-                expected = list(c(2:5, NA) * 1i))
-  expect_hybrid(list(lag(a)), a = 1:5 * 1i,
-                expected = list(c(NA, 1:4) * 1i))
+  expect_hybrid(
+    list(lead(a)), a = 1:5 * 1i,
+    expected = list(c(2:5, NA) * 1i)
+  )
+  expect_hybrid(
+    list(lag(a)), a = 1:5 * 1i,
+    expected = list(c(NA, 1:4) * 1i)
+  )
 
-  expect_hybrid(list(lead(a)), a = letters[1:5],
-                expected = list(c(letters[2:5], NA)))
-  expect_hybrid(list(lag(a)), a = letters[1:5],
-                expected = list(c(NA, letters[1:4])))
+  expect_hybrid(
+    list(lead(a)), a = letters[1:5],
+    expected = list(c(letters[2:5], NA))
+  )
+  expect_hybrid(
+    list(lag(a)), a = letters[1:5],
+    expected = list(c(NA, letters[1:4]))
+  )
 
-  expect_hybrid(list(lead(a)), a = c(TRUE, FALSE),
-                expected = list(c(FALSE, NA)))
-  expect_hybrid(list(lag(a)), a = c(TRUE, FALSE),
-                expected = list(c(NA, TRUE)))
+  expect_hybrid(
+    list(lead(a)), a = c(TRUE, FALSE),
+    expected = list(c(FALSE, NA))
+  )
+  expect_hybrid(
+    list(lag(a)), a = c(TRUE, FALSE),
+    expected = list(c(NA, TRUE))
+  )
 
-  expect_hybrid(list(lead(a, 1L + 2L)), a = 1:5,
-                expected = list(c(4:5, NA, NA, NA)))
-  expect_hybrid(list(lag(a, 4L - 2L)), a = as.numeric(1:5),
-                expected = list(c(NA, NA, as.numeric(1:3))))
+  expect_hybrid(
+    list(lead(a, 1L + 2L)), a = 1:5,
+    expected = list(c(4:5, NA, NA, NA))
+  )
+  expect_hybrid(
+    list(lag(a, 4L - 2L)), a = as.numeric(1:5),
+    expected = list(c(NA, NA, as.numeric(1:3)))
+  )
 
-  expect_hybrid(list(lead(a, 1 + 2)), a = 1:5,
-                expected = list(c(4:5, NA, NA, NA)))
-  expect_hybrid(list(lag(a, 4 - 2)), a = as.numeric(1:5),
-                expected = list(c(NA, NA, as.numeric(1:3))))
+  expect_hybrid(
+    list(lead(a, 1 + 2)), a = 1:5,
+    expected = list(c(4:5, NA, NA, NA))
+  )
+  expect_hybrid(
+    list(lag(a, 4 - 2)), a = as.numeric(1:5),
+    expected = list(c(NA, NA, as.numeric(1:3)))
+  )
 
-  expect_hybrid(list(lead(a, default = 2L + 4L)), a = 1:5,
-                expected = list(2:6))
-  expect_hybrid(list(lag(a, default = 3L - 3L)), a = 1:5,
-                expected = list(0:4))
+  expect_hybrid(
+    list(lead(a, default = 2L + 4L)), a = 1:5,
+    expected = list(2:6)
+  )
+  expect_hybrid(
+    list(lag(a, default = 3L - 3L)), a = 1:5,
+    expected = list(0:4)
+  )
 
-  expect_hybrid(list(lead(a, def = 2L + 4L)), a = 1:5,
-                expected = list(2:6))
-  expect_hybrid(list(lag(a, def = 3L - 3L)), a = 1:5,
-                expected = list(0:4))
+  expect_hybrid(
+    list(lead(a, def = 2L + 4L)), a = 1:5,
+    expected = list(2:6)
+  )
+  expect_hybrid(
+    list(lag(a, def = 3L - 3L)), a = 1:5,
+    expected = list(0:4)
+  )
 
-  expect_hybrid(list(lead(a, 2, 2L + 4L)), a = 1:5,
-                expected = list(c(3:6, 6L)))
-  expect_hybrid(list(lag(a, 3, 3L - 3L)), a = 1:5,
-                expected = list(c(0L, 0L, 0:2)))
+  expect_hybrid(
+    list(lead(a, 2, 2L + 4L)), a = 1:5,
+    expected = list(c(3:6, 6L))
+  )
+  expect_hybrid(
+    list(lag(a, 3, 3L - 3L)), a = 1:5,
+    expected = list(c(0L, 0L, 0:2))
+  )
 
-  expect_not_hybrid(list(lead(a, default = 2 + 4)), a = 1:5,
-                    expected = list(as.numeric(2:6)))
-  expect_not_hybrid(list(lag(a, default = 3L - 3L)), a = as.numeric(1:5),
-                    expected = list(as.numeric(0:4)))
+  expect_not_hybrid(
+    list(lead(a, default = 2 + 4)), a = 1:5,
+    expected = list(as.numeric(2:6))
+  )
+  expect_not_hybrid(
+    list(lag(a, default = 3L - 3L)), a = as.numeric(1:5),
+    expected = list(as.numeric(0:4))
+  )
 
-  expect_not_hybrid(list(lead(a, order_by = b)), a = 1:5, b = 5:1,
-                    expected = list(c(NA, 1:4)))
-  expect_not_hybrid(list(lag(a, order_by = b)), a = 1:5, b = 5:1,
-                    expected = list(c(2:5, NA)))
+  expect_not_hybrid(
+    list(lead(a, order_by = b)), a = 1:5, b = 5:1,
+    expected = list(c(NA, 1:4))
+  )
+  expect_not_hybrid(
+    list(lag(a, order_by = b)), a = 1:5, b = 5:1,
+    expected = list(c(2:5, NA))
+  )
 })
 
 test_that("mean(), var(), sd() and sum() work", {
-  expect_hybrid(mean(a), a = 1:5,
-                expected = 3)
-  expect_hybrid(var(a), a = 1:3,
-                expected = 1)
-  expect_hybrid(sd(a), a = 1:3,
-                expected = 1)
-  expect_hybrid(sum(a), a = 1:5,
-                expected = 15L)
-  expect_hybrid(sum(a), a = as.numeric(1:5),
-                expected = 15)
+  expect_hybrid(
+    mean(a), a = 1:5,
+    expected = 3
+  )
+  expect_hybrid(
+    var(a), a = 1:3,
+    expected = 1
+  )
+  expect_hybrid(
+    sd(a), a = 1:3,
+    expected = 1
+  )
+  expect_hybrid(
+    sum(a), a = 1:5,
+    expected = 15L
+  )
+  expect_hybrid(
+    sum(a), a = as.numeric(1:5),
+    expected = 15
+  )
 
-  expect_hybrid(mean(a), a = c(1:5, NA),
-                expected = NA_real_)
-  expect_hybrid(var(a), a = c(1:3, NA),
-                expected = NA_real_)
-  expect_hybrid(sd(a), a = c(1:3, NA),
-                expected = NA_real_)
-  expect_hybrid(sum(a), a = c(1:5, NA),
-                expected = NA_integer_)
-  expect_hybrid(sum(a), a = c(as.numeric(1:5), NA),
-                expected = NA_real_)
+  expect_hybrid(
+    mean(a), a = c(1:5, NA),
+    expected = NA_real_
+  )
+  expect_hybrid(
+    var(a), a = c(1:3, NA),
+    expected = NA_real_
+  )
+  expect_hybrid(
+    sd(a), a = c(1:3, NA),
+    expected = NA_real_
+  )
+  expect_hybrid(
+    sum(a), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  expect_hybrid(
+    sum(a), a = c(as.numeric(1:5), NA),
+    expected = NA_real_
+  )
 
-  expect_hybrid(mean(a, na.rm = (1 == 0)), a = c(1:5, NA),
-                expected = NA_real_)
-  expect_hybrid(var(a, na.rm = (1 == 0)), a = c(1:3, NA),
-                expected = NA_real_)
-  expect_hybrid(sd(a, na.rm = (1 == 0)), a = c(1:3, NA),
-                expected = NA_real_)
-  expect_hybrid(sum(a, na.rm = (1 == 0)), a = c(1:5, NA),
-                expected = NA_integer_)
-  expect_hybrid(sum(a, na.rm = (1 == 0)), a = c(as.numeric(1:5), NA),
-                expected = NA_real_)
+  expect_hybrid(
+    mean(a, na.rm = (1 == 0)), a = c(1:5, NA),
+    expected = NA_real_
+  )
+  expect_hybrid(
+    var(a, na.rm = (1 == 0)), a = c(1:3, NA),
+    expected = NA_real_
+  )
+  expect_hybrid(
+    sd(a, na.rm = (1 == 0)), a = c(1:3, NA),
+    expected = NA_real_
+  )
+  expect_hybrid(
+    sum(a, na.rm = (1 == 0)), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  expect_hybrid(
+    sum(a, na.rm = (1 == 0)), a = c(as.numeric(1:5), NA),
+    expected = NA_real_
+  )
 
-  expect_hybrid(mean(a, na.rm = (1 == 1)), a = c(1:5, NA),
-                expected = 3)
-  expect_hybrid(var(a, na.rm = (1 == 1)), a = c(1:3, NA),
-                expected = 1)
-  expect_hybrid(sd(a, na.rm = (1 == 1)), a = c(1:3, NA),
-                expected = 1)
-  expect_hybrid(sum(a, na.rm = (1 == 1)), a = c(1:5, NA),
-                expected = 15L)
-  expect_hybrid(sum(a, na.rm = (1 == 1)), a = c(as.numeric(1:5), NA),
-                expected = 15)
+  expect_hybrid(
+    mean(a, na.rm = (1 == 1)), a = c(1:5, NA),
+    expected = 3
+  )
+  expect_hybrid(
+    var(a, na.rm = (1 == 1)), a = c(1:3, NA),
+    expected = 1
+  )
+  expect_hybrid(
+    sd(a, na.rm = (1 == 1)), a = c(1:3, NA),
+    expected = 1
+  )
+  expect_hybrid(
+    sum(a, na.rm = (1 == 1)), a = c(1:5, NA),
+    expected = 15L
+  )
+  expect_hybrid(
+    sum(a, na.rm = (1 == 1)), a = c(as.numeric(1:5), NA),
+    expected = 15
+  )
 
-  expect_hybrid(mean(na.rm = (1 == 1), a), a = c(1:5, NA),
-                expected = 3)
-  expect_hybrid(var(na.rm = (1 == 1), a), a = c(1:3, NA),
-                expected = 1)
-  expect_hybrid(sd(na.rm = (1 == 1), a), a = c(1:3, NA),
-                expected = 1)
-  expect_hybrid(sum(na.rm = (1 == 1), a), a = c(1:5, NA),
-                expected = 15L)
-  expect_hybrid(sum(na.rm = (1 == 1), a), a = c(as.numeric(1:5), NA),
-                expected = 15)
+  expect_hybrid(
+    mean(na.rm = (1 == 1), a), a = c(1:5, NA),
+    expected = 3
+  )
+  expect_hybrid(
+    var(na.rm = (1 == 1), a), a = c(1:3, NA),
+    expected = 1
+  )
+  expect_hybrid(
+    sd(na.rm = (1 == 1), a), a = c(1:3, NA),
+    expected = 1
+  )
+  expect_hybrid(
+    sum(na.rm = (1 == 1), a), a = c(1:5, NA),
+    expected = 15L
+  )
+  expect_hybrid(
+    sum(na.rm = (1 == 1), a), a = c(as.numeric(1:5), NA),
+    expected = 15
+  )
 
-  expect_not_hybrid(sd(a, TRUE), a = c(1:3, NA),
-                    expected = 1)
+  expect_not_hybrid(
+    sd(a, TRUE), a = c(1:3, NA),
+    expected = 1
+  )
 
-  expect_not_hybrid(sd(a, na.rm = b[[1]]), a = c(1:3, NA), b = TRUE,
-                    expected = 1)
+  expect_not_hybrid(
+    sd(a, na.rm = b[[1]]), a = c(1:3, NA), b = TRUE,
+    expected = 1
+  )
 })
 
 test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and cume_dist() work", {
-  expect_hybrid(list(row_number()), a = 1:5,
-                expected = list(1:5),
-                test_eval = FALSE)
-  expect_hybrid(list(row_number(a)), a = 5:1,
-                expected = list(5:1))
-  expect_hybrid(list(min_rank(a)), a = c(1, 3, 2, 3, 1),
-                expected = list(c(1L, 4L, 3L, 4L, 1L)))
-  expect_hybrid(list(percent_rank(a)), a = c(1, 3, 2, 3, 1),
-                expected = list((c(1L, 4L, 3L, 4L, 1L) - 1) / 4))
-  expect_hybrid(list(cume_dist(a)), a = c(1, 3, 2, 3),
-                expected = list(c(0.25, 1.0, 0.5, 1.0)))
-  expect_hybrid(list(dense_rank(a)), a = c(1, 3, 2, 3, 1),
-                expected = list(c(1L, 3L, 2L, 3L, 1L)))
-  expect_hybrid(list(ntile(a, 1 + 2)), a = c(1, 3, 2, 3, 1),
-                expected = list(c(1L, 2L, 2L, 3L, 1L)))
-  expect_hybrid(list(ntile(a, 1L + 2L)), a = c(1, 3, 2, 3, 1),
-                expected = list(c(1L, 2L, 2L, 3L, 1L)))
-  expect_hybrid(list(ntile(n = 1 + 2, a)), a = c(1, 3, 2, 3, 1),
-                expected = list(c(1L, 2L, 2L, 3L, 1L)))
+  expect_hybrid(
+    list(row_number()), a = 1:5,
+    expected = list(1:5),
+                test_eval = FALSE
+  )
+  expect_hybrid(
+    list(row_number(a)), a = 5:1,
+    expected = list(5:1)
+  )
+  expect_hybrid(
+    list(min_rank(a)), a = c(1, 3, 2, 3, 1),
+    expected = list(c(1L, 4L, 3L, 4L, 1L))
+  )
+  expect_hybrid(
+    list(percent_rank(a)), a = c(1, 3, 2, 3, 1),
+    expected = list((c(1L, 4L, 3L, 4L, 1L) - 1) / 4)
+  )
+  expect_hybrid(
+    list(cume_dist(a)), a = c(1, 3, 2, 3),
+    expected = list(c(0.25, 1.0, 0.5, 1.0))
+  )
+  expect_hybrid(
+    list(dense_rank(a)), a = c(1, 3, 2, 3, 1),
+    expected = list(c(1L, 3L, 2L, 3L, 1L))
+  )
+  expect_hybrid(
+    list(ntile(a, 1 + 2)), a = c(1, 3, 2, 3, 1),
+    expected = list(c(1L, 2L, 2L, 3L, 1L))
+  )
+  expect_hybrid(
+    list(ntile(a, 1L + 2L)), a = c(1, 3, 2, 3, 1),
+    expected = list(c(1L, 2L, 2L, 3L, 1L))
+  )
+  expect_hybrid(
+    list(ntile(n = 1 + 2, a)), a = c(1, 3, 2, 3, 1),
+    expected = list(c(1L, 2L, 2L, 3L, 1L))
+  )
 
-  expect_not_hybrid_error(row_number(a, 1), a = 5:1,
-                          error = "unused argument")
-  expect_not_hybrid_error(min_rank(a, 1), a = 5:1,
-                          error = "unused argument")
-  expect_not_hybrid_error(percent_rank(a, 1), a = 5:1,
-                          error = "unused argument")
-  expect_not_hybrid_error(cume_dist(a, 1), a = 5:1,
-                          error = "unused argument")
-  expect_not_hybrid_error(dense_rank(a, 1), a = 5:1,
-                          error = "unused argument")
-  expect_not_hybrid_error(ntile(a, 2, 1), a = 5:1,
-                          error = "unused argument")
+  expect_not_hybrid_error(
+    row_number(a, 1), a = 5:1,
+    error = "unused argument"
+  )
+  expect_not_hybrid_error(
+    min_rank(a, 1), a = 5:1,
+    error = "unused argument"
+  )
+  expect_not_hybrid_error(
+    percent_rank(a, 1), a = 5:1,
+    error = "unused argument"
+  )
+  expect_not_hybrid_error(
+    cume_dist(a, 1), a = 5:1,
+    error = "unused argument"
+  )
+  expect_not_hybrid_error(
+    dense_rank(a, 1), a = 5:1,
+    error = "unused argument"
+  )
+  expect_not_hybrid_error(
+    ntile(a, 2, 1), a = 5:1,
+    error = "unused argument"
+  )
 })

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1,13 +1,5 @@
 context("hybrid")
 
-test_df <- data_frame(
-  id = c(1L, 2L, 2L),
-  a = 1:3,
-  b = as.numeric(1:3),
-  c = letters[1:3],
-  d = c(TRUE, FALSE, NA)
-)
-
 test_that("n() and n_distinct() work", {
   expect_hybrid(n(), a = 1:5, expected = 5L, test_eval = FALSE)
 
@@ -30,18 +22,27 @@ test_that("n() and n_distinct() work", {
 })
 
 test_that("%in% works (#192)", {
-  # Hybrid evaluation currently requires constants (#2143)
-  test_df_mutated <-
-    mutate(test_df,
-           a1 = a %in% 1L,
-           b1 = b %in% 1,
-           c1 = c %in% "a",
-           d1 = d %in% TRUE
-    )
+  expect_hybrid(list(a %in% 1:3), a = 2:4,
+                expected = list(c(TRUE, TRUE, FALSE)))
+  expect_hybrid(list(a %in% as.numeric(1:3)), a = as.numeric(2:4),
+                expected = list(c(TRUE, TRUE, FALSE)))
+  expect_hybrid(list(a %in% letters[1:3]), a = letters[2:4],
+                expected = list(c(TRUE, TRUE, FALSE)))
+  expect_hybrid(list(a %in% c(TRUE, FALSE)), a = c(TRUE, FALSE, NA),
+                expected = list(c(TRUE, TRUE, FALSE)))
 
-  expected <- c(TRUE, FALSE, FALSE)
-  expect_equal(test_df_mutated$a1, expected)
-  expect_equal(test_df_mutated$b1, expected)
-  expect_equal(test_df_mutated$c1, expected)
-  expect_equal(test_df_mutated$d1, expected)
+  expect_not_hybrid(list(a %in% 1:3), a = as.numeric(2:4),
+                    expected = list(c(TRUE, TRUE, FALSE)))
+  expect_not_hybrid(list(a %in% as.numeric(1:3)), a = 2:4,
+                expected = list(c(TRUE, TRUE, FALSE)))
+
+  skip("Currently failing")
+  expect_hybrid(list(a %in% NA_integer_), a = c(2:4, NA),
+                expected = list(c(FALSE, FALSE, FALSE, TRUE)))
+  expect_hybrid(list(a %in% NA_real_), a = as.numeric(c(2:4, NA)),
+                expected = list(c(FALSE, FALSE, FALSE, TRUE)))
+  expect_hybrid(list(a %in% NA_character_), a = c(letters[2:4], NA),
+                expected = list(c(FALSE, FALSE, FALSE, TRUE)))
+  expect_hybrid(list(a %in% NA), a = c(TRUE, FALSE, NA),
+                expected = list(c(FALSE, FALSE, TRUE)))
 })

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -23,6 +23,10 @@ test_that("n() and n_distinct() work", {
                     expected = 3L, test_eval = FALSE)
   expect_not_hybrid(n_distinct(a, c), a = 1:3,
                     expected = 3L, test_eval = FALSE)
+  expect_not_hybrid(n_distinct(a, b, na.rm = 1), a = rep(1L, 3), b = c(1, 1, NA),
+                    expected = 1L)
+  expect_not_hybrid_error(n_distinct(), a = 1:5,
+                          error = "need at least one column")
 })
 
 test_that("%in% works (#192)", {
@@ -38,7 +42,7 @@ test_that("%in% works (#192)", {
   expect_not_hybrid(list(a %in% 1:3), a = as.numeric(2:4),
                     expected = list(c(TRUE, TRUE, FALSE)))
   expect_not_hybrid(list(a %in% as.numeric(1:3)), a = 2:4,
-                expected = list(c(TRUE, TRUE, FALSE)))
+                    expected = list(c(TRUE, TRUE, FALSE)))
 
   skip("Currently failing")
   expect_hybrid(list(a %in% NA_integer_), a = c(2:4, NA),
@@ -72,6 +76,12 @@ test_that("min() and max() work", {
                 expected = 1L)
   expect_hybrid(max(a, na.rm = (1 == 1)), a = c(1:5, NA),
                 expected = 5L)
+
+  c <- 1:3
+  expect_not_hybrid(min(c), a = 1:5,
+                    expected = 1L)
+  expect_not_hybrid(max(c), a = 1:5,
+                    expected = 3L)
 
   expect_not_hybrid(min(a), a = letters,
                     expected = "a")
@@ -108,11 +118,17 @@ test_that("first(), last(), and nth() work", {
   expect_not_hybrid(nth(a, 2), a = as.list(1:5),
                     expected = 2L)
 
-  skip("Currently failing")
-  expect_hybrid(nth(a, order_by = 5:1, 2), a = 1:5,
-                expected = 4L)
-  expect_hybrid(first(a, order_by = b), a = 1:5, b = 5:1,
-                expected = 5L)
+  expect_not_hybrid(nth(a, order_by = 5:1, 2), a = 1:5,
+                    expected = 4L)
+  expect_not_hybrid(first(a, order_by = b), a = 1:5, b = 5:1,
+                    expected = 5L)
+
+  expect_not_hybrid_error(first(a, bogus = 3), a = 1:5,
+                          error = "unused argument")
+  expect_not_hybrid_error(last(a, bogus = 3), a = 1:5,
+                          error = "unused argument")
+  expect_not_hybrid_error(nth(a, 3, bogus = 3), a = 1:5,
+                          error = "unused argument")
 })
 
 test_that("lead() and lag() work", {
@@ -257,4 +273,17 @@ test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and 
                 expected = list(c(1L, 2L, 2L, 3L, 1L)))
   expect_hybrid(list(ntile(n = 1 + 2, a)), a = c(1, 3, 2, 3, 1),
                 expected = list(c(1L, 2L, 2L, 3L, 1L)))
+
+  expect_not_hybrid_error(row_number(a, 1), a = 5:1,
+                          error = "unused argument")
+  expect_not_hybrid_error(min_rank(a, 1), a = 5:1,
+                          error = "unused argument")
+  expect_not_hybrid_error(percent_rank(a, 1), a = 5:1,
+                          error = "unused argument")
+  expect_not_hybrid_error(cume_dist(a, 1), a = 5:1,
+                          error = "unused argument")
+  expect_not_hybrid_error(dense_rank(a, 1), a = 5:1,
+                          error = "unused argument")
+  expect_not_hybrid_error(ntile(a, 2, 1), a = 5:1,
+                          error = "unused argument")
 })

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -44,6 +44,10 @@ test_that("%in% works (#192)", {
   expect_not_hybrid(list(a %in% as.numeric(1:3)), a = 2:4,
                     expected = list(c(TRUE, TRUE, FALSE)))
 
+  c <- 2:4
+  expect_not_hybrid(list(c %in% 1:3), a = as.numeric(2:4),
+                    expected = list(c(TRUE, TRUE, FALSE)))
+
   skip("Currently failing")
   expect_hybrid(list(a %in% NA_integer_), a = c(2:4, NA),
                 expected = list(c(FALSE, FALSE, FALSE, TRUE)))
@@ -122,6 +126,14 @@ test_that("first(), last(), and nth() work", {
                     expected = 4L)
   expect_not_hybrid(first(a, order_by = b), a = 1:5, b = 5:1,
                     expected = 5L)
+
+  c <- 1:3
+  expect_not_hybrid(first(c), a = 2:4,
+                    expected = 1L)
+  expect_not_hybrid(last(c), a = 2:4,
+                    expected = 3L)
+  expect_not_hybrid(nth(c, 2), a = 2:4,
+                    expected = 2L)
 
   expect_not_hybrid_error(first(a, bogus = 3), a = 1:5,
                           error = "unused argument")

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -82,3 +82,19 @@ test_that("min() and max() work", {
   expect_not_hybrid(max(a, na.rm = TRUE), a = c(letters, NA),
                     expected = "z")
 })
+
+test_that("first(), last(), and nth() work", {
+  expect_hybrid(first(a), a = 1:5,
+                expected = 1L)
+  expect_hybrid(last(a), a = as.numeric(1:5),
+                expected = 5)
+  expect_hybrid(nth(a, 1 + 2), a = letters[1:5],
+                expected = "c")
+  expect_hybrid(nth(a, 6), a = as.numeric(1:5),
+                expected = NA_real_)
+  expect_hybrid(nth(a, 6.5), a = 1:5,
+                expected = NA_integer_)
+
+  expect_not_hybrid(nth(a, b[[2]]), a = letters[1:5], b = 5:1,
+                    expected = "d")
+})

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1,53 +1,54 @@
 context("hybrid")
 
 test_that("n() and n_distinct() work", {
-  expect_hybrid(
+  check_hybrid_result(
     n(), a = 1:5,
     expected = 5L, test_eval = FALSE
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     n_distinct(a), a = 1:5,
     expected = 5L
   )
-  expect_hybrid(
+  check_hybrid_result(
     n_distinct(a), a = rep(1L, 3),
     expected = 1L
   )
-  expect_hybrid(
+  check_hybrid_result(
     n_distinct(a, b), a = rep(1L, 3), b = 1:3,
     expected = 3L
   )
-  expect_hybrid(
+  check_hybrid_result(
     n_distinct(a, b), a = rep(1L, 3), b = c(1, 1, 2),
     expected = 2L
   )
-  expect_hybrid(
+  check_hybrid_result(
     n_distinct(a, b), a = rep(1L, 3), b = c(1, 1, NA),
     expected = 2L
   )
-  expect_hybrid(
+  check_hybrid_result(
     n_distinct(a, b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
     expected = 1L
   )
-  expect_hybrid(
+  check_hybrid_result(
     n_distinct(a = a, b = b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
     expected = 1L
   )
 
   c <- 1:3
-  expect_not_hybrid(
+  check_not_hybrid_result(
     n_distinct(c), a = 1:5,
     expected = 3L, test_eval = FALSE
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     n_distinct(a, c), a = 1:3,
     expected = 3L, test_eval = FALSE
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     n_distinct(a, b, na.rm = 1), a = rep(1L, 3), b = c(1, 1, NA),
     expected = 1L
   )
+
   expect_not_hybrid_error(
     n_distinct(), a = 1:5,
     error = "need at least one column"
@@ -55,204 +56,204 @@ test_that("n() and n_distinct() work", {
 })
 
 test_that("%in% works (#192)", {
-  expect_hybrid(
+  check_hybrid_result(
     list(a %in% 1:3), a = 2:4,
     expected = list(c(TRUE, TRUE, FALSE))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(a %in% as.numeric(1:3)), a = as.numeric(2:4),
     expected = list(c(TRUE, TRUE, FALSE))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(a %in% letters[1:3]), a = letters[2:4],
     expected = list(c(TRUE, TRUE, FALSE))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(a %in% c(TRUE, FALSE)), a = c(TRUE, FALSE, NA),
     expected = list(c(TRUE, TRUE, FALSE))
   )
 
   # compilation errors on Windows
   # https://ci.appveyor.com/project/hadley/dplyr/build/1.0.230
-  expect_not_hybrid(
+  check_not_hybrid_result(
     list(a %in% (1:3 * 1i)), a = 2:4 * 1i,
     expected = list(c(TRUE, TRUE, FALSE))
   )
 
-  expect_not_hybrid(
+  check_not_hybrid_result(
     list(a %in% 1:3), a = as.numeric(2:4),
     expected = list(c(TRUE, TRUE, FALSE))
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     list(a %in% as.numeric(1:3)), a = 2:4,
     expected = list(c(TRUE, TRUE, FALSE))
   )
 
   c <- 2:4
-  expect_not_hybrid(
+  check_not_hybrid_result(
     list(c %in% 1:3), a = as.numeric(2:4),
     expected = list(c(TRUE, TRUE, FALSE))
   )
 
   skip("Currently failing")
-  expect_hybrid(
+  check_hybrid_result(
     list(a %in% NA_integer_), a = c(2:4, NA),
     expected = list(c(FALSE, FALSE, FALSE, TRUE))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(a %in% NA_real_), a = as.numeric(c(2:4, NA)),
     expected = list(c(FALSE, FALSE, FALSE, TRUE))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(a %in% NA_character_), a = c(letters[2:4], NA),
     expected = list(c(FALSE, FALSE, FALSE, TRUE))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(a %in% NA), a = c(TRUE, FALSE, NA),
     expected = list(c(FALSE, FALSE, TRUE))
   )
 })
 
 test_that("min() and max() work", {
-  expect_hybrid(
+  check_hybrid_result(
     min(a), a = 1:5,
     expected = 1L
   )
-  expect_hybrid(
+  check_hybrid_result(
     max(a), a = 1:5,
     expected = 5L
   )
-  expect_hybrid(
+  check_hybrid_result(
     min(a), a = as.numeric(1:5),
     expected = 1
   )
-  expect_hybrid(
+  check_hybrid_result(
     max(a), a = as.numeric(1:5),
     expected = 5
   )
-  expect_hybrid(
+  check_hybrid_result(
     min(a), a = c(1:5, NA),
     expected = NA_integer_
   )
-  expect_hybrid(
+  check_hybrid_result(
     max(a), a = c(1:5, NA),
     expected = NA_integer_
   )
-  expect_hybrid(
+  check_hybrid_result(
     min(a, na.rm = (1 == 0)), a = c(1:5, NA),
     expected = NA_integer_
   )
-  expect_hybrid(
+  check_hybrid_result(
     max(a, na.rm = (1 == 0)), a = c(1:5, NA),
     expected = NA_integer_
   )
-  expect_hybrid(
+  check_hybrid_result(
     min(a, na.rm = (1 == 1)), a = c(1:5, NA),
     expected = 1L
   )
-  expect_hybrid(
+  check_hybrid_result(
     max(a, na.rm = (1 == 1)), a = c(1:5, NA),
     expected = 5L
   )
 
   c <- 1:3
-  expect_not_hybrid(
+  check_not_hybrid_result(
     min(c), a = 1:5,
     expected = 1L
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     max(c), a = 1:5,
     expected = 3L
   )
 
-  expect_not_hybrid(
+  check_not_hybrid_result(
     min(a), a = letters,
     expected = "a"
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     max(a), a = letters,
     expected = "z"
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     min(a), a = c(letters, NA),
     expected = NA_character_
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     max(a), a = c(letters, NA),
     expected = NA_character_
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     min(a, na.rm = TRUE), a = c(letters, NA),
     expected = "a"
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     max(a, na.rm = TRUE), a = c(letters, NA),
     expected = "z"
   )
 })
 
 test_that("first(), last(), and nth() work", {
-  expect_hybrid(
+  check_hybrid_result(
     first(a), a = 1:5,
     expected = 1L
   )
-  expect_hybrid(
+  check_hybrid_result(
     last(a), a = as.numeric(1:5),
     expected = 5
   )
-  expect_hybrid(
+  check_hybrid_result(
     nth(a, 3), a = as.numeric(1:5) * 1i,
     expected = 3i
   )
-  expect_hybrid(
+  check_hybrid_result(
     nth(a, 1 + 2), a = letters[1:5],
     expected = "c"
   )
-  expect_hybrid(
+  check_hybrid_result(
     nth(a, 6, default = 3L), a = as.numeric(1:5),
     expected = 3
   )
-  expect_hybrid(
+  check_hybrid_result(
     nth(a, 6, def = 3L), a = as.numeric(1:5),
     expected = 3
   )
-  expect_hybrid(
+  check_hybrid_result(
     nth(a, 6.5), a = 1:5,
     expected = NA_integer_
   )
-  expect_hybrid(
+  check_hybrid_result(
     nth(a, -4), a = 1:5,
     expected = 2L
   )
 
-  expect_not_hybrid(
+  check_not_hybrid_result(
     nth(a, b[[2]]), a = letters[1:5], b = 5:1,
     expected = "d"
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     nth(a, 2), a = as.list(1:5),
     expected = 2L
   )
 
-  expect_not_hybrid(
+  check_not_hybrid_result(
     nth(a, order_by = 5:1, 2), a = 1:5,
     expected = 4L
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     first(a, order_by = b), a = 1:5, b = 5:1,
     expected = 5L
   )
 
   c <- 1:3
-  expect_not_hybrid(
+  check_not_hybrid_result(
     first(c), a = 2:4,
     expected = 1L
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     last(c), a = 2:4,
     expected = 3L
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     nth(c, 2), a = 2:4,
     expected = 2L
   )
@@ -272,267 +273,267 @@ test_that("first(), last(), and nth() work", {
 })
 
 test_that("lead() and lag() work", {
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a)), a = 1:5,
     expected = list(c(2:5, NA))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a)), a = 1:5,
     expected = list(c(NA, 1:4))
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a)), a = as.numeric(1:5),
     expected = list(c(as.numeric(2:5), NA))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a)), a = as.numeric(1:5),
     expected = list(c(NA, as.numeric(1:4)))
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a)), a = 1:5 * 1i,
     expected = list(c(2:5, NA) * 1i)
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a)), a = 1:5 * 1i,
     expected = list(c(NA, 1:4) * 1i)
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a)), a = letters[1:5],
     expected = list(c(letters[2:5], NA))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a)), a = letters[1:5],
     expected = list(c(NA, letters[1:4]))
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a)), a = c(TRUE, FALSE),
     expected = list(c(FALSE, NA))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a)), a = c(TRUE, FALSE),
     expected = list(c(NA, TRUE))
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a, 1L + 2L)), a = 1:5,
     expected = list(c(4:5, NA, NA, NA))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a, 4L - 2L)), a = as.numeric(1:5),
     expected = list(c(NA, NA, as.numeric(1:3)))
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a, 1 + 2)), a = 1:5,
     expected = list(c(4:5, NA, NA, NA))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a, 4 - 2)), a = as.numeric(1:5),
     expected = list(c(NA, NA, as.numeric(1:3)))
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a, default = 2L + 4L)), a = 1:5,
     expected = list(2:6)
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a, default = 3L - 3L)), a = 1:5,
     expected = list(0:4)
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a, def = 2L + 4L)), a = 1:5,
     expected = list(2:6)
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a, def = 3L - 3L)), a = 1:5,
     expected = list(0:4)
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     list(lead(a, 2, 2L + 4L)), a = 1:5,
     expected = list(c(3:6, 6L))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(lag(a, 3, 3L - 3L)), a = 1:5,
     expected = list(c(0L, 0L, 0:2))
   )
 
-  expect_not_hybrid(
+  check_not_hybrid_result(
     list(lead(a, default = 2 + 4)), a = 1:5,
     expected = list(as.numeric(2:6))
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     list(lag(a, default = 3L - 3L)), a = as.numeric(1:5),
     expected = list(as.numeric(0:4))
   )
 
-  expect_not_hybrid(
+  check_not_hybrid_result(
     list(lead(a, order_by = b)), a = 1:5, b = 5:1,
     expected = list(c(NA, 1:4))
   )
-  expect_not_hybrid(
+  check_not_hybrid_result(
     list(lag(a, order_by = b)), a = 1:5, b = 5:1,
     expected = list(c(2:5, NA))
   )
 })
 
 test_that("mean(), var(), sd() and sum() work", {
-  expect_hybrid(
+  check_hybrid_result(
     mean(a), a = 1:5,
     expected = 3
   )
-  expect_hybrid(
+  check_hybrid_result(
     var(a), a = 1:3,
     expected = 1
   )
-  expect_hybrid(
+  check_hybrid_result(
     sd(a), a = 1:3,
     expected = 1
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(a), a = 1:5,
     expected = 15L
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(a), a = as.numeric(1:5),
     expected = 15
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     mean(a), a = c(1:5, NA),
     expected = NA_real_
   )
-  expect_hybrid(
+  check_hybrid_result(
     var(a), a = c(1:3, NA),
     expected = NA_real_
   )
-  expect_hybrid(
+  check_hybrid_result(
     sd(a), a = c(1:3, NA),
     expected = NA_real_
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(a), a = c(1:5, NA),
     expected = NA_integer_
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(a), a = c(as.numeric(1:5), NA),
     expected = NA_real_
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     mean(a, na.rm = (1 == 0)), a = c(1:5, NA),
     expected = NA_real_
   )
-  expect_hybrid(
+  check_hybrid_result(
     var(a, na.rm = (1 == 0)), a = c(1:3, NA),
     expected = NA_real_
   )
-  expect_hybrid(
+  check_hybrid_result(
     sd(a, na.rm = (1 == 0)), a = c(1:3, NA),
     expected = NA_real_
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(a, na.rm = (1 == 0)), a = c(1:5, NA),
     expected = NA_integer_
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(a, na.rm = (1 == 0)), a = c(as.numeric(1:5), NA),
     expected = NA_real_
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     mean(a, na.rm = (1 == 1)), a = c(1:5, NA),
     expected = 3
   )
-  expect_hybrid(
+  check_hybrid_result(
     var(a, na.rm = (1 == 1)), a = c(1:3, NA),
     expected = 1
   )
-  expect_hybrid(
+  check_hybrid_result(
     sd(a, na.rm = (1 == 1)), a = c(1:3, NA),
     expected = 1
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(a, na.rm = (1 == 1)), a = c(1:5, NA),
     expected = 15L
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(a, na.rm = (1 == 1)), a = c(as.numeric(1:5), NA),
     expected = 15
   )
 
-  expect_hybrid(
+  check_hybrid_result(
     mean(na.rm = (1 == 1), a), a = c(1:5, NA),
     expected = 3
   )
-  expect_hybrid(
+  check_hybrid_result(
     var(na.rm = (1 == 1), a), a = c(1:3, NA),
     expected = 1
   )
-  expect_hybrid(
+  check_hybrid_result(
     sd(na.rm = (1 == 1), a), a = c(1:3, NA),
     expected = 1
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(na.rm = (1 == 1), a), a = c(1:5, NA),
     expected = 15L
   )
-  expect_hybrid(
+  check_hybrid_result(
     sum(na.rm = (1 == 1), a), a = c(as.numeric(1:5), NA),
     expected = 15
   )
 
-  expect_not_hybrid(
+  check_not_hybrid_result(
     sd(a, TRUE), a = c(1:3, NA),
     expected = 1
   )
 
-  expect_not_hybrid(
+  check_not_hybrid_result(
     sd(a, na.rm = b[[1]]), a = c(1:3, NA), b = TRUE,
     expected = 1
   )
 })
 
 test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and cume_dist() work", {
-  expect_hybrid(
+  check_hybrid_result(
     list(row_number()), a = 1:5,
     expected = list(1:5),
                 test_eval = FALSE
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(row_number(a)), a = 5:1,
     expected = list(5:1)
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(min_rank(a)), a = c(1, 3, 2, 3, 1),
     expected = list(c(1L, 4L, 3L, 4L, 1L))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(percent_rank(a)), a = c(1, 3, 2, 3, 1),
     expected = list((c(1L, 4L, 3L, 4L, 1L) - 1) / 4)
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(cume_dist(a)), a = c(1, 3, 2, 3),
     expected = list(c(0.25, 1.0, 0.5, 1.0))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(dense_rank(a)), a = c(1, 3, 2, 3, 1),
     expected = list(c(1L, 3L, 2L, 3L, 1L))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(ntile(a, 1 + 2)), a = c(1, 3, 2, 3, 1),
     expected = list(c(1L, 2L, 2L, 3L, 1L))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(ntile(a, 1L + 2L)), a = c(1, 3, 2, 3, 1),
     expected = list(c(1L, 2L, 2L, 3L, 1L))
   )
-  expect_hybrid(
+  check_hybrid_result(
     list(ntile(n = 1 + 2, a)), a = c(1, 3, 2, 3, 1),
     expected = list(c(1L, 2L, 2L, 3L, 1L))
   )

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -199,3 +199,21 @@ test_that("mean(), var(), sd() and sum() work", {
   expect_not_hybrid(sd(a, TRUE), a = c(1:3, NA),
                 expected = 1)
 })
+
+test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and cume_dist() work", {
+  expect_hybrid(list(row_number()), a = 1:5,
+                expected = list(1:5),
+                test_eval = FALSE)
+  expect_hybrid(list(row_number(a)), a = 5:1,
+                expected = list(5:1))
+  expect_hybrid(list(min_rank(a)), a = c(1, 3, 2, 3, 1),
+                expected = list(c(1L, 4L, 3L, 4L, 1L)))
+  expect_hybrid(list(percent_rank(a)), a = c(1, 3, 2, 3, 1),
+                expected = list((c(1L, 4L, 3L, 4L, 1L) - 1) / 4))
+  expect_hybrid(list(cume_dist(a)), a = c(1, 3, 2, 3),
+                expected = list(c(0.25, 1.0, 0.5, 1.0)))
+  expect_hybrid(list(dense_rank(a)), a = c(1, 3, 2, 3, 1),
+                expected = list(c(1L, 3L, 2L, 3L, 1L)))
+  expect_hybrid(list(ntile(a, 1 + 2)), a = c(1, 3, 2, 3, 1),
+                expected = list(c(1L, 2L, 2L, 3L, 1L)))
+})

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -8,6 +8,27 @@ test_df <- data_frame(
   d = c(TRUE, FALSE, NA)
 )
 
+test_that("n() and n_distinct() work", {
+  expect_hybrid(n(), a = 1:5, expected = 5L, test_eval = FALSE)
+
+  expect_hybrid(n_distinct(a), a = 1:5,
+                expected = 5L)
+  expect_hybrid(n_distinct(a), a = rep(1L, 3),
+                expected = 1L)
+  expect_hybrid(n_distinct(a, b), a = rep(1L, 3), b = 1:3,
+                expected = 3L)
+  expect_hybrid(n_distinct(a, b), a = rep(1L, 3), b = c(1, 1, 2),
+                expected = 2L)
+  expect_hybrid(n_distinct(a, b), a = rep(1L, 3), b = c(1, 1, NA),
+                expected = 2L)
+  expect_hybrid(n_distinct(a, b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
+                expected = 1L)
+
+  c <- 1:3
+  expect_not_hybrid(n_distinct(c), a = 1:5,
+                    expected = 3L, test_eval = FALSE)
+})
+
 test_that("%in% works (#192)", {
   # Hybrid evaluation currently requires constants (#2143)
   test_df_mutated <-

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -15,9 +15,13 @@ test_that("n() and n_distinct() work", {
                 expected = 2L)
   expect_hybrid(n_distinct(a, b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
                 expected = 1L)
+  expect_hybrid(n_distinct(a = a, b = b, na.rm = TRUE), a = rep(1L, 3), b = c(1, 1, NA),
+                expected = 1L)
 
   c <- 1:3
   expect_not_hybrid(n_distinct(c), a = 1:5,
+                    expected = 3L, test_eval = FALSE)
+  expect_not_hybrid(n_distinct(a, c), a = 1:3,
                     expected = 3L, test_eval = FALSE)
 })
 
@@ -137,6 +141,11 @@ test_that("lead() and lag() work", {
   expect_hybrid(list(lag(a)), a = c(TRUE, FALSE),
                 expected = list(c(NA, TRUE)))
 
+  expect_hybrid(list(lead(a, 1L + 2L)), a = 1:5,
+                expected = list(c(4:5, NA, NA, NA)))
+  expect_hybrid(list(lag(a, 4L - 2L)), a = as.numeric(1:5),
+                expected = list(c(NA, NA, as.numeric(1:3))))
+
   expect_hybrid(list(lead(a, 1 + 2)), a = 1:5,
                 expected = list(c(4:5, NA, NA, NA)))
   expect_hybrid(list(lag(a, 4 - 2)), a = as.numeric(1:5),
@@ -243,6 +252,8 @@ test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and 
   expect_hybrid(list(dense_rank(a)), a = c(1, 3, 2, 3, 1),
                 expected = list(c(1L, 3L, 2L, 3L, 1L)))
   expect_hybrid(list(ntile(a, 1 + 2)), a = c(1, 3, 2, 3, 1),
+                expected = list(c(1L, 2L, 2L, 3L, 1L)))
+  expect_hybrid(list(ntile(a, 1L + 2L)), a = c(1, 3, 2, 3, 1),
                 expected = list(c(1L, 2L, 2L, 3L, 1L)))
   expect_hybrid(list(ntile(n = 1 + 2, a)), a = c(1, 3, 2, 3, 1),
                 expected = list(c(1L, 2L, 2L, 3L, 1L)))

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -98,3 +98,55 @@ test_that("first(), last(), and nth() work", {
   expect_not_hybrid(nth(a, b[[2]]), a = letters[1:5], b = 5:1,
                     expected = "d")
 })
+
+test_that("lead() and lag() work", {
+  expect_hybrid(list(lead(a)), a = 1:5,
+                expected = list(c(2:5, NA)))
+  expect_hybrid(list(lag(a)), a = 1:5,
+                expected = list(c(NA, 1:4)))
+
+  expect_hybrid(list(lead(a)), a = as.numeric(1:5),
+                expected = list(c(as.numeric(2:5), NA)))
+  expect_hybrid(list(lag(a)), a = as.numeric(1:5),
+                expected = list(c(NA, as.numeric(1:4))))
+
+  expect_hybrid(list(lead(a)), a = 1:5 * 1i,
+                expected = list(c(2:5, NA) * 1i))
+  expect_hybrid(list(lag(a)), a = 1:5 * 1i,
+                expected = list(c(NA, 1:4) * 1i))
+
+  expect_hybrid(list(lead(a)), a = letters[1:5],
+                expected = list(c(letters[2:5], NA)))
+  expect_hybrid(list(lag(a)), a = letters[1:5],
+                expected = list(c(NA, letters[1:4])))
+
+  expect_hybrid(list(lead(a)), a = c(TRUE, FALSE),
+                expected = list(c(FALSE, NA)))
+  expect_hybrid(list(lag(a)), a = c(TRUE, FALSE),
+                expected = list(c(NA, TRUE)))
+
+  expect_hybrid(list(lead(a, 1 + 2)), a = 1:5,
+                expected = list(c(4:5, NA, NA, NA)))
+  expect_hybrid(list(lag(a, 4 - 2)), a = as.numeric(1:5),
+                expected = list(c(NA, NA, as.numeric(1:3))))
+
+  expect_hybrid(list(lead(a, default = 2L + 4L)), a = 1:5,
+                expected = list(2:6))
+  expect_hybrid(list(lag(a, default = 3L - 3L)), a = 1:5,
+                expected = list(0:4))
+
+  expect_hybrid(list(lead(a, 2, 2L + 4L)), a = 1:5,
+                expected = list(c(3:6, 6L)))
+  expect_hybrid(list(lag(a, 3, 3L - 3L)), a = 1:5,
+                expected = list(c(0L, 0L, 0:2)))
+
+  expect_not_hybrid(list(lead(a, default = 2 + 4)), a = 1:5,
+                    expected = list(as.numeric(2:6)))
+  expect_not_hybrid(list(lag(a, default = 3L - 3L)), a = as.numeric(1:5),
+                    expected = list(as.numeric(0:4)))
+
+  expect_not_hybrid(list(lead(a, order_by = b)), a = 1:5, b = 5:1,
+                    expected = list(c(NA, 1:4)))
+  expect_not_hybrid(list(lag(a, order_by = b)), a = 1:5, b = 5:1,
+                    expected = list(c(2:5, NA)))
+})

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -270,6 +270,9 @@ test_that("mean(), var(), sd() and sum() work", {
 
   expect_not_hybrid(sd(a, TRUE), a = c(1:3, NA),
                     expected = 1)
+
+  expect_not_hybrid(sd(a, na.rm = b[[1]]), a = c(1:3, NA), b = TRUE,
+                    expected = 1)
 })
 
 test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and cume_dist() work", {

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -34,6 +34,8 @@ test_that("%in% works (#192)", {
                 expected = list(c(TRUE, TRUE, FALSE)))
   expect_hybrid(list(a %in% as.numeric(1:3)), a = as.numeric(2:4),
                 expected = list(c(TRUE, TRUE, FALSE)))
+  expect_hybrid(list(a %in% (1:3 * 1i)), a = 2:4 * 1i,
+                expected = list(c(TRUE, TRUE, FALSE)))
   expect_hybrid(list(a %in% letters[1:3]), a = letters[2:4],
                 expected = list(c(TRUE, TRUE, FALSE)))
   expect_hybrid(list(a %in% c(TRUE, FALSE)), a = c(TRUE, FALSE, NA),
@@ -106,6 +108,8 @@ test_that("first(), last(), and nth() work", {
                 expected = 1L)
   expect_hybrid(last(a), a = as.numeric(1:5),
                 expected = 5)
+  expect_hybrid(nth(a, 3), a = as.numeric(1:5) * 1i,
+                expected = 3i)
   expect_hybrid(nth(a, 1 + 2), a = letters[1:5],
                 expected = "c")
   expect_hybrid(nth(a, 6, default = 3L), a = as.numeric(1:5),

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -225,6 +225,16 @@ test_that("min() and max() work", {
     max(a, na.rm = T), a = c(1:5, NA),
     expected = 5L
   )
+
+  skip("Currently failing (#2305)")
+  check_hybrid_result(
+    min(a, na.rm = TRUE), a = NA_real_,
+    expected = Inf
+  )
+  check_hybrid_result(
+    max(a, na.rm = TRUE), a = NA_integer_,
+    expected = -Inf
+  )
 })
 
 test_that("first(), last(), and nth() work", {

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -156,6 +156,40 @@ test_that("min() and max() work", {
     expected = 5L
   )
 
+  check_hybrid_result(
+    min(a, na.rm = pi != pi), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    max(a, na.rm = pi != pi), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    min(a, na.rm = pi == pi), a = c(1:5, NA),
+    expected = 1L
+  )
+  check_hybrid_result(
+    max(a, na.rm = pi == pi), a = c(1:5, NA),
+    expected = 5L
+  )
+
+  check_hybrid_result(
+    min(a, na.rm = F), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    max(a, na.rm = F), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    min(a, na.rm = T), a = c(1:5, NA),
+    expected = 1L
+  )
+  check_hybrid_result(
+    max(a, na.rm = T), a = c(1:5, NA),
+    expected = 5L
+  )
+
   c <- 1:3
   check_not_hybrid_result(
     min(c), a = 1:5,

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -92,6 +92,8 @@ test_that("first(), last(), and nth() work", {
                 expected = "c")
   expect_hybrid(nth(a, 6, default = 3L), a = as.numeric(1:5),
                 expected = 3)
+  expect_hybrid(nth(a, 6, def = 3L), a = as.numeric(1:5),
+                expected = 3)
   expect_hybrid(nth(a, 6.5), a = 1:5,
                 expected = NA_integer_)
   expect_hybrid(nth(a, -4), a = 1:5,
@@ -143,6 +145,11 @@ test_that("lead() and lag() work", {
   expect_hybrid(list(lead(a, default = 2L + 4L)), a = 1:5,
                 expected = list(2:6))
   expect_hybrid(list(lag(a, default = 3L - 3L)), a = 1:5,
+                expected = list(0:4))
+
+  expect_hybrid(list(lead(a, def = 2L + 4L)), a = 1:5,
+                expected = list(2:6))
+  expect_hybrid(list(lag(a, def = 3L - 3L)), a = 1:5,
                 expected = list(0:4))
 
   expect_hybrid(list(lead(a, 2, 2L + 4L)), a = 1:5,
@@ -206,8 +213,19 @@ test_that("mean(), var(), sd() and sum() work", {
   expect_hybrid(sum(a, na.rm = (1 == 1)), a = c(as.numeric(1:5), NA),
                 expected = 15)
 
-  expect_not_hybrid(sd(a, TRUE), a = c(1:3, NA),
+  expect_hybrid(mean(na.rm = (1 == 1), a), a = c(1:5, NA),
+                expected = 3)
+  expect_hybrid(var(na.rm = (1 == 1), a), a = c(1:3, NA),
                 expected = 1)
+  expect_hybrid(sd(na.rm = (1 == 1), a), a = c(1:3, NA),
+                expected = 1)
+  expect_hybrid(sum(na.rm = (1 == 1), a), a = c(1:5, NA),
+                expected = 15L)
+  expect_hybrid(sum(na.rm = (1 == 1), a), a = c(as.numeric(1:5), NA),
+                expected = 15)
+
+  expect_not_hybrid(sd(a, TRUE), a = c(1:3, NA),
+                    expected = 1)
 })
 
 test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and cume_dist() work", {
@@ -225,5 +243,7 @@ test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and 
   expect_hybrid(list(dense_rank(a)), a = c(1, 3, 2, 3, 1),
                 expected = list(c(1L, 3L, 2L, 3L, 1L)))
   expect_hybrid(list(ntile(a, 1 + 2)), a = c(1, 3, 2, 3, 1),
+                expected = list(c(1L, 2L, 2L, 3L, 1L)))
+  expect_hybrid(list(ntile(n = 1 + 2, a)), a = c(1, 3, 2, 3, 1),
                 expected = list(c(1L, 2L, 2L, 3L, 1L)))
 })

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -34,12 +34,15 @@ test_that("%in% works (#192)", {
                 expected = list(c(TRUE, TRUE, FALSE)))
   expect_hybrid(list(a %in% as.numeric(1:3)), a = as.numeric(2:4),
                 expected = list(c(TRUE, TRUE, FALSE)))
-  expect_hybrid(list(a %in% (1:3 * 1i)), a = 2:4 * 1i,
-                expected = list(c(TRUE, TRUE, FALSE)))
   expect_hybrid(list(a %in% letters[1:3]), a = letters[2:4],
                 expected = list(c(TRUE, TRUE, FALSE)))
   expect_hybrid(list(a %in% c(TRUE, FALSE)), a = c(TRUE, FALSE, NA),
                 expected = list(c(TRUE, TRUE, FALSE)))
+
+  # compilation errors on Windows
+  # https://ci.appveyor.com/project/hadley/dplyr/build/1.0.230
+  expect_not_hybrid(list(a %in% (1:3 * 1i)), a = 2:4 * 1i,
+                    expected = list(c(TRUE, TRUE, FALSE)))
 
   expect_not_hybrid(list(a %in% 1:3), a = as.numeric(2:4),
                     expected = list(c(TRUE, TRUE, FALSE)))

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -46,3 +46,39 @@ test_that("%in% works (#192)", {
   expect_hybrid(list(a %in% NA), a = c(TRUE, FALSE, NA),
                 expected = list(c(FALSE, FALSE, TRUE)))
 })
+
+test_that("min() and max() work", {
+  expect_hybrid(min(a), a = 1:5,
+                expected = 1L)
+  expect_hybrid(max(a), a = 1:5,
+                expected = 5L)
+  expect_hybrid(min(a), a = as.numeric(1:5),
+                expected = 1)
+  expect_hybrid(max(a), a = as.numeric(1:5),
+                expected = 5)
+  expect_hybrid(min(a), a = c(1:5, NA),
+                expected = NA_integer_)
+  expect_hybrid(max(a), a = c(1:5, NA),
+                expected = NA_integer_)
+  expect_hybrid(min(a, na.rm = (1 == 0)), a = c(1:5, NA),
+                expected = NA_integer_)
+  expect_hybrid(max(a, na.rm = (1 == 0)), a = c(1:5, NA),
+                expected = NA_integer_)
+  expect_hybrid(min(a, na.rm = (1 == 1)), a = c(1:5, NA),
+                expected = 1L)
+  expect_hybrid(max(a, na.rm = (1 == 1)), a = c(1:5, NA),
+                expected = 5L)
+
+  expect_not_hybrid(min(a), a = letters,
+                    expected = "a")
+  expect_not_hybrid(max(a), a = letters,
+                    expected = "z")
+  expect_not_hybrid(min(a), a = c(letters, NA),
+                    expected = NA_character_)
+  expect_not_hybrid(max(a), a = c(letters, NA),
+                    expected = NA_character_)
+  expect_not_hybrid(min(a, na.rm = TRUE), a = c(letters, NA),
+                    expected = "a")
+  expect_not_hybrid(max(a, na.rm = TRUE), a = c(letters, NA),
+                    expected = "z")
+})

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -173,23 +173,6 @@ test_that("min() and max() work", {
     expected = 5L
   )
 
-  check_hybrid_result(
-    min(a, na.rm = F), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    max(a, na.rm = F), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    min(a, na.rm = T), a = c(1:5, NA),
-    expected = 1L
-  )
-  check_hybrid_result(
-    max(a, na.rm = T), a = c(1:5, NA),
-    expected = 5L
-  )
-
   c <- 1:3
   check_not_hybrid_result(
     min(c), a = 1:5,
@@ -223,6 +206,24 @@ test_that("min() and max() work", {
   check_not_hybrid_result(
     max(a, na.rm = TRUE), a = c(letters, NA),
     expected = "z"
+  )
+
+  skip("Currently failing")
+  check_hybrid_result(
+    min(a, na.rm = F), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    max(a, na.rm = F), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    min(a, na.rm = T), a = c(1:5, NA),
+    expected = 1L
+  )
+  check_hybrid_result(
+    max(a, na.rm = T), a = c(1:5, NA),
+    expected = 5L
   )
 })
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -248,7 +248,7 @@ test_that("hybrid evaluation goes deep enough (#554)", {
 })
 
 test_that("hybrid does not segfault when given non existing variable (#569)", {
-  expect_error( mtcars %>% summarise(first(mp)), "could not find variable" )
+  expect_error( mtcars %>% summarise(first(mp)), "object 'mp' not found" )
 })
 
 test_that("namespace extraction works in hybrid (#412)", {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -346,7 +346,7 @@ test_that("nth handle negative value (#1584) ", {
 
 test_that( "LazyGroupSubsets is robust about columns not from the data (#600)", {
   foo <- data_frame(x = 1:10, y = 1:10)
-  expect_error( foo %>% group_by(x) %>% summarise(first_y = first(z)), "could not find variable" )
+  expect_error( foo %>% group_by(x) %>% summarise(first_y = first(z)), "object 'z' not found" )
 })
 
 test_that( "hybrid eval handles $ and @ (#645)", {


### PR DESCRIPTION
- New `with_hybrid()`, `without_hybrid()` and `eval_dots()` allow evaluating an expression
    1. inside dplyr, asserting that hybrid evaluation is used
    1. inside dplyr, asserting that hybrid evaluation is not used
    1. outside dplyr

- Improved and simplified hybrid prototypes
    - using `match.call()` for proper argument matching
    - using constant folding where appropriate
    - better support for complex arguments

- Comprehensive (?) tests for functions that use hybrid evaluation

Fixes #1691.

Fixes #2143.

@hadley: PTAL.