### PR TITLE
Refactor GroupedHybridCall

### DIFF
--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -307,9 +307,12 @@ namespace dplyr {
     typename Data::slicing_index indices = *git;
     RObject first(proxy.get(indices));
 
+    check_supported_type(first, name.c_str());
+
     if (Rf_inherits(first, "POSIXlt")) {
       stop("`mutate` does not support `POSIXlt` results");
     }
+
     int ng = gdf.ngroups();
     int i = 0;
     while (all_na(first)) {
@@ -341,7 +344,6 @@ namespace dplyr {
       break;
     }
 
-    check_supported_type(first, name.c_str());
     return 0;
   }
 

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -49,10 +49,10 @@ namespace dplyr {
     SEXP get(const SlicingIndex& indices) {
       subsets.clear();
 
-      return get_hybrid_call()->eval(indices);
+      return get_hybrid_eval()->eval(indices);
     }
 
-    GroupedHybridEval* get_hybrid_call() {
+    GroupedHybridEval* get_hybrid_eval() {
       if (!hybrid_eval) {
         hybrid_eval.reset(new GroupedHybridEval(call, subsets, env));
       }

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -15,8 +15,6 @@ namespace dplyr {
   template <typename Data = GroupedDataFrame, typename Subsets = LazyGroupedSubsets>
   class GroupedCallProxy {
   public:
-    typedef GroupedHybridEval HybridCall;
-
     GroupedCallProxy(const Rcpp::Call& call_, const Subsets& subsets_, const Environment& env_) :
       subsets(subsets_), proxies()
     {
@@ -54,9 +52,9 @@ namespace dplyr {
       return get_hybrid_call()->eval(indices);
     }
 
-    HybridCall* get_hybrid_call() {
+    GroupedHybridEval* get_hybrid_call() {
       if (!hybrid_eval) {
-        hybrid_eval.reset(new HybridCall(call, subsets, env));
+        hybrid_eval.reset(new GroupedHybridEval(call, subsets, env));
       }
 
       return hybrid_eval.get();
@@ -99,7 +97,7 @@ namespace dplyr {
     Subsets subsets;
     std::vector<CallElementProxy> proxies;
     Environment env;
-    boost::scoped_ptr<HybridCall> hybrid_eval;
+    boost::scoped_ptr<GroupedHybridEval> hybrid_eval;
 
   };
 

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -51,12 +51,12 @@ namespace dplyr {
     SEXP get(const SlicingIndex& indices) {
       subsets.clear();
 
-      return get_hybrid_call()->eval(call, indices);
+      return get_hybrid_call()->eval(indices);
     }
 
     HybridCall* get_hybrid_call() {
       if (!hybrid_call) {
-        hybrid_call.reset(new HybridCall(subsets, env));
+        hybrid_call.reset(new HybridCall(call, subsets, env));
       }
 
       return hybrid_call.get();
@@ -64,6 +64,7 @@ namespace dplyr {
 
     void set_call(SEXP call_) {
       proxies.clear();
+      hybrid_call.reset();
       call = call_;
     }
 

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -15,7 +15,7 @@ namespace dplyr {
   template <typename Data = GroupedDataFrame, typename Subsets = LazyGroupedSubsets>
   class GroupedCallProxy {
   public:
-    typedef GroupedHybridEval<Subsets> HybridCall;
+    typedef GroupedHybridEval HybridCall;
 
     GroupedCallProxy(const Rcpp::Call& call_, const Subsets& subsets_, const Environment& env_) :
       subsets(subsets_), proxies()

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -15,7 +15,7 @@ namespace dplyr {
   template <typename Data = GroupedDataFrame, typename Subsets = LazyGroupedSubsets>
   class GroupedCallProxy {
   public:
-    typedef GroupedHybridCall<Subsets> HybridCall;
+    typedef GroupedHybridEval<Subsets> HybridCall;
 
     GroupedCallProxy(const Rcpp::Call& call_, const Subsets& subsets_, const Environment& env_) :
       subsets(subsets_), proxies()

--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -55,27 +55,27 @@ namespace dplyr {
     }
 
     HybridCall* get_hybrid_call() {
-      if (!hybrid_call) {
-        hybrid_call.reset(new HybridCall(call, subsets, env));
+      if (!hybrid_eval) {
+        hybrid_eval.reset(new HybridCall(call, subsets, env));
       }
 
-      return hybrid_call.get();
+      return hybrid_eval.get();
     }
 
     void set_call(SEXP call_) {
       proxies.clear();
-      hybrid_call.reset();
+      hybrid_eval.reset();
       call = call_;
     }
 
     inline void set_env(SEXP env_) {
       env = env_;
-      hybrid_call.reset();
+      hybrid_eval.reset();
     }
 
     void input(Symbol name, SEXP x) {
       subsets.input(name, x);
-      hybrid_call.reset();
+      hybrid_eval.reset();
     }
 
     inline int nsubsets() const {
@@ -99,7 +99,7 @@ namespace dplyr {
     Subsets subsets;
     std::vector<CallElementProxy> proxies;
     Environment env;
-    boost::scoped_ptr<HybridCall> hybrid_call;
+    boost::scoped_ptr<HybridCall> hybrid_eval;
 
   };
 

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -69,10 +69,9 @@ namespace dplyr {
     mutable bool has_eval_env;
   };
 
-  template <typename Subsets>
   class GroupedHybridCall {
   public:
-    GroupedHybridCall(const Call& call_, const Subsets& subsets_, const Environment& env_) :
+    GroupedHybridCall(const Call& call_, const ILazySubsets& subsets_, const Environment& env_) :
       original_call(call_), subsets(subsets_), env(env_)
     {
       LOG_VERBOSE;
@@ -140,7 +139,7 @@ namespace dplyr {
   private:
     // Initialization
     const Call original_call;
-    const Subsets& subsets;
+    const ILazySubsets& subsets;
     const Environment env;
 
   private:
@@ -148,10 +147,9 @@ namespace dplyr {
     mutable const SlicingIndex* indices;
   };
 
-  template <typename Subsets>
   class GroupedHybridEval : public IHybridCallback {
   public:
-    GroupedHybridEval(const Call& call_, const Subsets& subsets_, const Environment& env_) :
+    GroupedHybridEval(const Call& call_, const ILazySubsets& subsets_, const Environment& env_) :
       indices(NULL), subsets(subsets_), env(env_),
       hybrid_env(subsets_.get_variable_names(), env_, this),
       hybrid_call(call_, subsets_, env_)
@@ -204,10 +202,10 @@ namespace dplyr {
 
   private:
     const SlicingIndex* indices;
-    const Subsets& subsets;
+    const ILazySubsets& subsets;
     Environment env;
     const GroupedHybridEnv hybrid_env;
-    const GroupedHybridCall<Subsets> hybrid_call;
+    const GroupedHybridCall hybrid_call;
   };
 
 }

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -70,9 +70,9 @@ namespace dplyr {
   };
 
   template <typename Subsets>
-  class GroupedHybridCall : public IHybridCallback {
+  class GroupedHybridEval : public IHybridCallback {
   public:
-    GroupedHybridCall(const Call& call_, Subsets& subsets_, const Environment& env_) :
+    GroupedHybridEval(const Call& call_, Subsets& subsets_, const Environment& env_) :
       call(call_), indices(NULL), subsets(subsets_), env(env_),
       hybrid_env(subsets_.get_variable_names(), env_, this)
     {

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -140,7 +140,6 @@ namespace dplyr {
     const SlicingIndex* indices;
     Subsets& subsets;
     Environment env, eval_env;
-    CharacterVector active_names;
     bool has_eval_env;
   };
 

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -11,13 +11,82 @@
 
 namespace dplyr {
 
-  template <typename Subsets>
-  class GroupedHybridCall {
+  class IHybridCallback {
+  protected:
+    virtual ~IHybridCallback() {}
+
   public:
-    GroupedHybridCall(const Call& call_, Subsets& subsets_, const Environment& env_) :
-      call(call_), indices(NULL), subsets(subsets_), env(env_), has_eval_env(false)
+    virtual SEXP get_subset(const Symbol& name) const = 0;
+  };
+
+  class GroupedHybridEnv {
+  public:
+    GroupedHybridEnv(const CharacterVector& names_, const Environment& env_, const IHybridCallback* callback_) :
+      names(names_), env(env_), callback(callback_), has_eval_env(false)
     {
       LOG_VERBOSE;
+    }
+
+  public:
+    const Environment& get_eval_env() const {
+      provide_eval_env();
+      return eval_env;
+    }
+
+  private:
+    void provide_eval_env() const {
+      if (has_eval_env)
+        return;
+
+      // Environment::new_child() performs an R callback, creating the environment
+      // in R should be slightly faster
+      Environment active_env =
+        create_env_symbol(
+          names, &GroupedHybridEnv::hybrid_get_callback,
+          PAYLOAD(const_cast<void*>(reinterpret_cast<const void*>(callback))), env);
+
+      // If bindr (via bindrcpp) supported the creation of a child environment, we could save the
+      // call to Rcpp_eval() triggered by active_env.new_child()
+      eval_env = active_env.new_child(true);
+      eval_env[".data"] = active_env;
+      eval_env[".env"] = env;
+
+      has_eval_env = true;
+    }
+
+    static SEXP hybrid_get_callback(const Symbol& name, bindrcpp::PAYLOAD payload) {
+      LOG_VERBOSE;
+      IHybridCallback* callback_ = reinterpret_cast<IHybridCallback*>(payload.p);
+      return callback_->get_subset(name);
+    }
+
+  private:
+    const CharacterVector names;
+    const Environment env;
+    const IHybridCallback* callback;
+
+    mutable Environment eval_env;
+    mutable bool has_eval_env;
+  };
+
+  template <typename Subsets>
+  class GroupedHybridCall : public IHybridCallback {
+  public:
+    GroupedHybridCall(const Call& call_, Subsets& subsets_, const Environment& env_) :
+      call(call_), indices(NULL), subsets(subsets_), env(env_),
+      hybrid_env(subsets_.get_variable_names(), env_, this)
+    {
+      LOG_VERBOSE;
+    }
+
+    const SlicingIndex& get_indices() const {
+      return *indices;
+    }
+
+  public: // IHybridCallback
+    SEXP get_subset(const Symbol& name) const {
+      LOG_VERBOSE;
+      return subsets.get(name, get_indices());
     }
 
   public:
@@ -29,47 +98,6 @@ namespace dplyr {
     }
 
   private:
-    const Environment& get_eval_env() {
-      provide_eval_env();
-      return eval_env;
-    }
-
-    void provide_eval_env() {
-      if (has_eval_env)
-        return;
-
-      // bindr::populate_env() does less work in R, I'm assuming that creating the environment from C++ will be faster
-      Environment active_env = env.new_child(true);
-
-      CharacterVector names = subsets.get_variable_names();
-      if (names.length() > 0) {
-        populate_env_symbol(
-          active_env, names,
-          &GroupedHybridCall::hybrid_get_callback, PAYLOAD(reinterpret_cast<void*>(this)));
-      }
-
-      eval_env = active_env.new_child(true);
-      eval_env[".data"] = active_env;
-      eval_env[".env"] = env;
-
-      has_eval_env = true;
-    }
-
-    static SEXP hybrid_get_callback(const Symbol& name, bindrcpp::PAYLOAD payload) {
-      LOG_VERBOSE;
-      GroupedHybridCall* this_ = reinterpret_cast<GroupedHybridCall*>(payload.p);
-      return this_->get_subset(name);
-    }
-
-    SEXP get_subset(Symbol name) {
-      LOG_VERBOSE;
-      return subsets.get(name, get_indices());
-    }
-
-    const SlicingIndex& get_indices() const {
-      return *indices;
-    }
-
     void set_indices(const SlicingIndex& indices_) {
       indices = &indices_;
     }
@@ -88,7 +116,7 @@ namespace dplyr {
       LOG_INFO << type2name(call);
       if (TYPEOF(call) == LANGSXP) {
         LOG_VERBOSE << "performing evaluation in eval_env";
-        return Rcpp_eval(call, get_eval_env());
+        return Rcpp_eval(call, hybrid_env.get_eval_env());
       } else if (TYPEOF(call) == SYMSXP) {
         if (subsets.count(call)) {
           return subsets.get(call, get_indices());
@@ -139,8 +167,8 @@ namespace dplyr {
     const Call& call;
     const SlicingIndex* indices;
     Subsets& subsets;
-    Environment env, eval_env;
-    bool has_eval_env;
+    Environment env;
+    const GroupedHybridEnv hybrid_env;
   };
 
 }

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -90,7 +90,7 @@ namespace dplyr {
     bool simplified(Call& call) const {
       LOG_VERBOSE;
       // initial
-      if (TYPEOF(call) == LANGSXP) {
+      if (TYPEOF(call) == LANGSXP || TYPEOF(call) == SYMSXP) {
         boost::scoped_ptr<Result> res(get_handler(call, subsets, env));
         if (res) {
           // replace the call by the result of process
@@ -99,7 +99,8 @@ namespace dplyr {
           // no need to go any further, we simplified the top level
           return true;
         }
-        return replace(CDR(call));
+        if (TYPEOF(call) == LANGSXP)
+          return replace(CDR(call));
       }
       return false;
     }
@@ -188,14 +189,9 @@ namespace dplyr {
       Call call = hybrid_call.simplify(get_indices());
       LOG_INFO << type2name(call);
 
-      if (TYPEOF(call) == LANGSXP) {
+      if (TYPEOF(call) == LANGSXP || TYPEOF(call) == SYMSXP) {
         LOG_VERBOSE << "performing evaluation in eval_env";
         return Rcpp_eval(call, hybrid_env.get_eval_env());
-      } else if (TYPEOF(call) == SYMSXP) {
-        if (subsets.count(call)) {
-          return subsets.get(call, get_indices());
-        }
-        return env.find(CHAR(PRINTNAME(call)));
       }
       return call;
     }

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -72,7 +72,7 @@ namespace dplyr {
   template <typename Subsets>
   class GroupedHybridCall {
   public:
-    GroupedHybridCall(const Call& call_, Subsets& subsets_, const Environment& env_) :
+    GroupedHybridCall(const Call& call_, const Subsets& subsets_, const Environment& env_) :
       original_call(call_), subsets(subsets_), env(env_)
     {
       LOG_VERBOSE;
@@ -140,7 +140,7 @@ namespace dplyr {
   private:
     // Initialization
     const Call original_call;
-    Subsets& subsets;
+    const Subsets& subsets;
     const Environment env;
 
   private:

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -151,7 +151,7 @@ namespace dplyr {
   template <typename Subsets>
   class GroupedHybridEval : public IHybridCallback {
   public:
-    GroupedHybridEval(const Call& call_, Subsets& subsets_, const Environment& env_) :
+    GroupedHybridEval(const Call& call_, const Subsets& subsets_, const Environment& env_) :
       indices(NULL), subsets(subsets_), env(env_),
       hybrid_env(subsets_.get_variable_names(), env_, this),
       hybrid_call(call_, subsets_, env_)
@@ -204,7 +204,7 @@ namespace dplyr {
 
   private:
     const SlicingIndex* indices;
-    Subsets& subsets;
+    const Subsets& subsets;
     Environment env;
     const GroupedHybridEnv hybrid_env;
     const GroupedHybridCall<Subsets> hybrid_call;

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -14,16 +14,16 @@ namespace dplyr {
   template <typename Subsets>
   class GroupedHybridCall {
   public:
-    GroupedHybridCall(Subsets& subsets_, const Environment& env_) :
-      indices(NULL), subsets(subsets_), env(env_), has_eval_env(false)
+    GroupedHybridCall(const Call& call_, Subsets& subsets_, const Environment& env_) :
+      call(call_), indices(NULL), subsets(subsets_), env(env_), has_eval_env(false)
     {
       LOG_VERBOSE;
     }
 
   public:
-    SEXP eval(const Call& call, const SlicingIndex& indices_) {
+    SEXP eval(const SlicingIndex& indices_) {
       set_indices(indices_);
-      SEXP ret = eval_with_indices(call);
+      SEXP ret = eval_with_indices();
       clear_indices();
       return ret;
     }
@@ -78,11 +78,13 @@ namespace dplyr {
       indices = NULL;
     }
 
-    SEXP eval_with_indices(const Call& call_) {
-      LOG_INFO << type2name(call_);
-      Call call = clone(call_);
-      while (simplified(call)) {}
+    SEXP eval_with_indices() {
+      Call call_ = clone(call);
+      while (simplified(call_)) {}
+      return eval_with_indices_simplified(call_);
+    }
 
+    SEXP eval_with_indices_simplified(const Call& call) {
       LOG_INFO << type2name(call);
       if (TYPEOF(call) == LANGSXP) {
         LOG_VERBOSE << "performing evaluation in eval_env";
@@ -134,6 +136,7 @@ namespace dplyr {
     }
 
   private:
+    const Call& call;
     const SlicingIndex* indices;
     Subsets& subsets;
     Environment env, eval_env;

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -161,36 +161,7 @@ SEXP mutate_grouped(const DataFrame& df, const LazyDots& dots) {
 
     LOG_VERBOSE << "processing " << CharacterVector(name);
 
-    if (TYPEOF(call) == SYMSXP) {
-      if (proxy.has_variable(call)) {
-        SEXP variable = variables[i] = proxy.get_variable(PRINTNAME(call));
-        proxy.input(name, variable);
-        accumulator.set(name, variable);
-      } else {
-        SEXP v = env.find(CHAR(PRINTNAME(call)));
-        check_supported_type(v, name.c_str());
-        if (Rf_isNull(v)) {
-          stop("unknown variable: %s", CHAR(PRINTNAME(call)));
-        } else if (Rf_length(v) == 1) {
-          boost::scoped_ptr<Gatherer> rep(constant_gatherer(v, gdf.nrows()));
-          SEXP variable = variables[i] = rep->collect();
-          proxy.input(name, variable);
-          accumulator.set(name, variable);
-        } else {
-          int n = Rf_length(v);
-          bool test = all(gdf.get_group_sizes() == n).is_true();
-          if (!test) {
-            stop("impossible to replicate vector of size %d", n);
-          }
-
-          boost::scoped_ptr<Replicator> rep(replicator<Data>(v, gdf));
-          SEXP variable = variables[i] = rep->collect();
-          proxy.input(name, variable);
-          accumulator.set(name, variable);
-        }
-      }
-
-    } else if (TYPEOF(call) == LANGSXP) {
+    if (TYPEOF(call) == LANGSXP || TYPEOF(call) == SYMSXP) {
       proxy.set_call(call);
       boost::scoped_ptr<Gatherer> gather(gatherer<Data, Subsets>(proxy, gdf, name));
       SEXP variable = variables[i] = gather->collect();

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -53,8 +53,11 @@ SEXP summarise_grouped(const DataFrame& df, const LazyDots& dots) {
     SEXP expr = expr_;
     boost::scoped_ptr<Result> res(get_handler(expr, subsets, env));
 
-    // if we could not find a direct Result
-    // we can use a GroupedCallReducer which will callback to R
+    // If we could not find a direct Result,
+    // we can use a GroupedCallReducer which will callback to R.
+    // Note that the GroupedCallReducer currently doesn't apply
+    // special treatment to summary variables, for which hybrid
+    // evaluation should be turned off completely (#2312)
     if (!res) {
       res.reset(new GroupedCallReducer<Data, Subsets>(lazy.expr(), subsets, env));
     }

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -517,7 +517,7 @@ test_that("grouped mutate does not drop grouping attributes (#1020)", {
 
 test_that("grouped mutate errors on incompatible column type (#1641)", {
   df <- data.frame(ID = rep(1:5, each = 3), x = 1:15) %>% group_by(ID)
-  expect_error( mutate(df, foo = mean), 'Not a vector')
+  expect_error( mutate(df, foo = mean), 'Unsupported type CLOSXP for column "foo"')
 })
 
 test_that("grouped mutate coerces integer + double -> double (#1892)", {

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -517,7 +517,7 @@ test_that("grouped mutate does not drop grouping attributes (#1020)", {
 
 test_that("grouped mutate errors on incompatible column type (#1641)", {
   df <- data.frame(ID = rep(1:5, each = 3), x = 1:15) %>% group_by(ID)
-  expect_error( mutate(df, foo = mean), 'Unsupported type CLOSXP for column "foo"')
+  expect_error( mutate(df, foo = mean), 'Not a vector')
 })
 
 test_that("grouped mutate coerces integer + double -> double (#1892)", {


### PR DESCRIPTION
- Split in three classes
- Introduce VariableResult, a hybrid handler that returns a data frame variable
- Simplify mutate_grouped()

Performance doesn't seem to be affected. @hadley: PTAL. CC @lionel-.