### PR TITLE
Fix groups when joining grouped data frames with duplicates (#2330)

### DIFF
--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -105,7 +105,7 @@ DataFrame build_index_cpp(DataFrame data) {
   for (int i=0; i<nsymbols; i++) {
     int pos = indx[i];
     if (pos == NA_INTEGER) {
-      stop("unknown column '%s' ", CHAR(names[i]));
+      stop("unknown column '%s' ", CHAR(vars[i]));
     }
 
     SEXP v = data[pos-1];

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -129,6 +129,11 @@ test_that("grouped_df errors on empty vars (#398)",{
   expect_error( m %>% do(mpg = mean(.$mpg)) )
 })
 
+test_that("grouped_df errors on non-existent var (#2330)", {
+  df <- data.frame(x = 1:5)
+  expect_error(grouped_df(df, list(quote(y))), "unknown column 'y'")
+})
+
 test_that("group_by only creates one group for NA (#401)", {
   x <- as.numeric(c(NA,NA,NA,10:1,10:1))
   w <- c(20,30,40,1:10,1:10)*10

--- a/tests/testthat/test-group-indices.R
+++ b/tests/testthat/test-group-indices.R
@@ -22,3 +22,12 @@ test_that("group_indices can be used in mutate (#2160)", {
   res2 <- mtcars %>% mutate(group_idx = as.integer(factor(cyl)))
   expect_equal(res1, res2)
 })
+
+test_that("group indices are updated correctly for joined grouped data frames (#2330)", {
+  d1 <- data.frame(x = 1:2, y = 1:2) %>% group_by(x, y)
+  expect_equal(group_indices(d1), d1$x)
+
+  d2 <- expand.grid(x = 1:2, y = 1:2)
+  res <- inner_join(d1, d2, by = "x")
+  expect_equal(group_indices(res), res$x)
+})

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -370,6 +370,21 @@ test_that("joins between factor and character coerces to character with a warnin
 
 })
 
+test_that("group column names reflect renamed duplicate columns (#2330)", {
+  d1 <- data_frame(x = 1:5, y = 1:5) %>% group_by(x, y)
+  d2 <- data_frame(x = 1:5, y = 1:5)
+  res <- inner_join(d1, d2, by = "x")
+  expect_equal(groups(d1), list(quote(x), quote(y)))
+  expect_equal(groups(res), list(quote(x), quote(y.x)))
+})
+
+test_that("group column names are null when joined data frames are not grouped (#2330)", {
+  d1 <- data_frame(x = 1:5, y = 1:5)
+  d2 <- data_frame(x = 1:5, y = 1:5)
+  res <- inner_join(d1, d2, by = "x")
+  expect_null(groups(res))
+})
+
 # Guessing variables in x and y ------------------------------------------------
 
 test_that("unnamed vars are the same in both tables", {


### PR DESCRIPTION
* Fix subset_join to update group column names in attribute
vars when they are duplicate column names and get renamed.

* Add a test to verify that the group column names after
join are all columns in the data frame.

* Fix build_index_cpp to report correct missing group
column name. Currently when a group column name does not
exist in the data frame, it reports a name from the names 
vector (all columns) instead of the vars vector (group columns).

Fixes #2330.