### PR TITLE
Add test for crash in issue #2166.

### DIFF
--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -40,3 +40,10 @@ test_that("default value errors for complicated structures", {
   expect_error(default_missing(factor("a")), "generate default for object")
   expect_error(default_missing(mtcars), "generate default for object")
 })
+
+test_that("nth and order_by doesn't crash", {
+    # Bug from issue #2166
+    data_frame(SBP = rnorm(2)) %>%
+    mutate(visit=1) %>%
+    summarise(FIRST_SBP_DPLYR=first(SBP, order_by=visit))
+})

--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -43,7 +43,7 @@ test_that("default value errors for complicated structures", {
 
 test_that("nth and order_by doesn't crash (#2166)", {
   skip("Currently failing")
-  data_frame(SBP = c(1, 1)) %>%
-    mutate(visit = 1) %>%
-    summarise(FIRST_SBP_DPLYR = first(SBP, order_by = visit))
+  data_frame(x = c(1, 1)) %>%
+    mutate(y = 1) %>%
+    summarise(z = first(x, order_by = y))
 })

--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -41,9 +41,9 @@ test_that("default value errors for complicated structures", {
   expect_error(default_missing(mtcars), "generate default for object")
 })
 
-test_that("nth and order_by doesn't crash", {
-    # Bug from issue #2166
-    data_frame(SBP = rnorm(2)) %>%
-    mutate(visit=1) %>%
-    summarise(FIRST_SBP_DPLYR=first(SBP, order_by=visit))
+test_that("nth and order_by doesn't crash (#2166)", {
+  skip("Currently failing")
+  data_frame(SBP = c(1, 1)) %>%
+    mutate(visit = 1) %>%
+    summarise(FIRST_SBP_DPLYR = first(SBP, order_by = visit))
 })


### PR DESCRIPTION
Summarise nth and order_by crashes R in both Windows and Ubuntu.
This commit triggers that crash, with code pulled from @avsmith's issue.

Apparently this issue does not affect Macs.