### PR TITLE
fix documentation about collapse grouping

### DIFF
--- a/R/compute-collect.r
+++ b/R/compute-collect.r
@@ -8,8 +8,7 @@
 #'
 #' @section Grouping:
 #'
-#' \code{compute} and \code{collect} preserve grouping, \code{collapse} drops
-#' it.
+#' \code{compute}, \code{collect}, and \code{collapse} preserve grouping.
 #'
 #' @param x a data tbl
 #' @param name name of temporary table on database.


### PR DESCRIPTION
This documentation seems to be out of date since collapse in `R/tbl-sql.r` has grouping  https://github.com/hadley/dplyr/blob/165b7603f17d66e2caf2b837f716c9c1ec977bd4/R/tbl-sql.r#L374. And there is a test to make sure that collapse preserves grouping: https://github.com/hadley/dplyr/blob/master/tests/testthat/test-group-by.r#L25.