### PR TITLE
Fix group_by() for column names in UTF-8 on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.5.0.9000
 
+* Fix `group_by()` for data frames that have UTF-8 encoded names (#2284, #2382).
+
 * Fix `copy_to()` for MySQL if a character column contains `NA` (#1975, #2256, #2263, #2381, @demorenoc, @eduardgrebe).
 
 * Fix `group_size()` and `n_groups()` for MySQL (#2381).

--- a/inst/include/dplyr/DataFrameSubsetVisitors.h
+++ b/inst/include/dplyr/DataFrameSubsetVisitors.h
@@ -2,6 +2,7 @@
 #define dplyr_DataFrameSubsetVisitors_H
 
 #include <tools/pointer_vector.h>
+#include <tools/match.h>
 #include <tools/utils.h>
 
 #include <dplyr/tbl_cpp.h>
@@ -40,18 +41,17 @@ namespace dplyr {
       nvisitors(visitor_names.size())
     {
 
-      std::string name;
-      int n = names.size();
-      for (int i=0; i<n; i++) {
-        name = (String)names[i];
-        SEXP column;
+      IntegerVector indx = r_match(names, data.names());
 
-        try {
-          column = data[name];
-        } catch (...) {
+      int n = indx.size();
+      for (int i=0; i<n; i++) {
+
+        int pos = indx[i];
+        if (pos == NA_INTEGER) {
           stop("unknown column '%s' ", name);
         }
-        SubsetVectorVisitor* v = subset_visitor(column);
+
+        SubsetVectorVisitor* v = subset_visitor(data[pos - 1]);
         visitors.push_back(v);
 
       }

--- a/inst/include/dplyr/DataFrameSubsetVisitors.h
+++ b/inst/include/dplyr/DataFrameSubsetVisitors.h
@@ -48,7 +48,7 @@ namespace dplyr {
 
         int pos = indx[i];
         if (pos == NA_INTEGER) {
-          stop("unknown column '%s' ", name);
+          stop("unknown column '%s' ", CHAR(names[i]));
         }
 
         SubsetVectorVisitor* v = subset_visitor(data[pos - 1]);

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -9,7 +9,7 @@ using namespace dplyr;
 
 SEXP select_not_grouped(const DataFrame& df, const CharacterVector& keep, CharacterVector new_names) {
   CharacterVector names = df.names();
-  IntegerVector positions = match(keep, names);
+  IntegerVector positions = r_match(keep, names);
   int n = keep.size();
   List res(n);
   for (int i=0; i<n; i++) {
@@ -52,7 +52,7 @@ DataFrame select_grouped(GroupedDataFrame gdf, const CharacterVector& keep, Char
 
   copy.attr("vars") = vars;
 
-  // hangle labels attribute
+  // handle labels attribute
   //   make a shallow copy of the data frame and alter its names attributes
   if (!Rf_isNull(copy.attr("labels"))) {
 
@@ -61,7 +61,7 @@ DataFrame select_grouped(GroupedDataFrame gdf, const CharacterVector& keep, Char
     DataFrame labels(shallow_copy(original_labels));
     CharacterVector label_names = clone<CharacterVector>(labels.names());
 
-    IntegerVector positions = match(label_names, keep);
+    IntegerVector positions = r_match(label_names, keep);
     int nl = label_names.size();
     for (int i=0; i<nl; i++) {
       label_names[i] = new_names[ positions[i]-1 ];

--- a/tests/testthat/helper-encoding.R
+++ b/tests/testthat/helper-encoding.R
@@ -1,0 +1,6 @@
+lang_strings <- c(
+  de = "Gl\u00fcck",
+  cn = "\u5e78\u798f",
+  ru = "\u0441\u0447\u0430\u0441\u0442\u044c\u0435",
+  ko = "\ud589\ubcf5"
+)

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -242,14 +242,23 @@ test_that( "group_by supports column (#1012)", {
   expect_equal( attr(g1, "vars"), attr(g4, "vars"))
 })
 
-test_that("group_by handles encodings (#1507)", {
-  skip_on_os("windows") # 1950
+for (special in c("Gl\u00fcck", "\u5e78\u798f", "\u0441\u0447\u0430\u0441\u0442\u044c\u0435", "\ud589\ubcf5")) {
+  if (enc2native(special) == special) {
+    test_that(paste0("group_by handles encodings for ", special, " (#1507)"), {
 
-  df <- data.frame(x=1:3, Eng=2:4)
-  names(df) <- enc2utf8(c("\u00e9", "Eng"))
-  res <- group_by_(df, iconv("\u00e9", from = "UTF-8", to = "latin1") )
-  expect_equal( names(res), names(df) )
-})
+      df <- data.frame(x = 1:3, Eng = 2:4)
+
+      for (names_converter in c(enc2utf8, enc2native)) {
+        for (dots_converter in c(enc2native, enc2utf8)) {
+          names(df) <- names_converter(c(special, "Eng"))
+          res <- group_by_(df, .dots = dots_converter(special))
+          expect_equal( names(res), names(df) )
+          expect_equal( groups(res), list(as.name(enc2native(special))) )
+        }
+      }
+    })
+  }
+}
 
 test_that("group_by fails gracefully on raw columns (#1803)", {
   df <- data_frame(a = 1:3, b = as.raw(1:3))

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -212,9 +212,9 @@ test_that("[ on grouped_df drops grouping if subset doesn't include grouping var
 test_that("group_by works after arrange (#959)",{
   df  <- data_frame(Log= c(1,2,1,2,1,2), Time = c(10,1,3,0,15,11))
   res <- df %>%
-     arrange(Time) %>%
-     group_by(Log) %>%
-     mutate(Diff = Time - lag(Time))
+    arrange(Time) %>%
+    group_by(Log) %>%
+    mutate(Diff = Time - lag(Time))
   expect_true( all(is.na( res$Diff[ c(1,3) ] )))
   expect_equal( res$Diff[ c(2,4,5,6) ], c(1,7,10,5) )
 })

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -248,7 +248,7 @@ for (special in lang_strings) {
 
       df <- data.frame(x = 1:3, Eng = 2:4)
 
-      for (names_converter in c(enc2utf8, enc2native)) {
+      for (names_converter in c(enc2native, enc2utf8)) {
         for (dots_converter in c(enc2native, enc2utf8)) {
           names(df) <- names_converter(c(special, "Eng"))
           res <- group_by_(df, .dots = dots_converter(special))

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -242,7 +242,7 @@ test_that( "group_by supports column (#1012)", {
   expect_equal( attr(g1, "vars"), attr(g4, "vars"))
 })
 
-for (special in c("Gl\u00fcck", "\u5e78\u798f", "\u0441\u0447\u0430\u0441\u0442\u044c\u0435", "\ud589\ubcf5")) {
+for (special in lang_strings) {
   if (enc2native(special) == special) {
     test_that(paste0("group_by handles encodings for ", special, " (#1507)"), {
 


### PR DESCRIPTION
Fixes #2284. Similar to #2058 but at a lower level.

Fixes #2005 and #2277.