### PR TITLE
Get rid of grouped_indices_impl()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -106,10 +106,6 @@ grouped_indices_grouped_df_impl <- function(gdf) {
     .Call('dplyr_grouped_indices_grouped_df_impl', PACKAGE = 'dplyr', gdf)
 }
 
-grouped_indices_impl <- function(data, symbols) {
-    .Call('dplyr_grouped_indices_impl', PACKAGE = 'dplyr', data, symbols)
-}
-
 group_size_grouped_cpp <- function(gdf) {
     .Call('dplyr_group_size_grouped_cpp', PACKAGE = 'dplyr', gdf)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -86,6 +86,14 @@ filter_impl <- function(df, dots) {
     .Call('dplyr_filter_impl', PACKAGE = 'dplyr', df, dots)
 }
 
+grouped_indices_grouped_df_impl <- function(gdf) {
+    .Call('dplyr_grouped_indices_grouped_df_impl', PACKAGE = 'dplyr', gdf)
+}
+
+group_size_grouped_cpp <- function(gdf) {
+    .Call('dplyr_group_size_grouped_cpp', PACKAGE = 'dplyr', gdf)
+}
+
 resolve_vars <- function(new_groups, names) {
     .Call('dplyr_resolve_vars', PACKAGE = 'dplyr', new_groups, names)
 }
@@ -100,14 +108,6 @@ as_regular_df <- function(df) {
 
 ungroup_grouped_df <- function(df) {
     .Call('dplyr_ungroup_grouped_df', PACKAGE = 'dplyr', df)
-}
-
-grouped_indices_grouped_df_impl <- function(gdf) {
-    .Call('dplyr_grouped_indices_grouped_df_impl', PACKAGE = 'dplyr', gdf)
-}
-
-group_size_grouped_cpp <- function(gdf) {
-    .Call('dplyr_group_size_grouped_cpp', PACKAGE = 'dplyr', gdf)
 }
 
 semi_join_impl <- function(x, y, by_x, by_y) {

--- a/R/group-indices.R
+++ b/R/group-indices.R
@@ -21,8 +21,11 @@ group_indices_ <- function(.data, ..., .dots) {
 
 #' @export
 group_indices_.data.frame <- function(.data, ..., .dots ){
-  groups <- group_by_prepare(.data, .dots = .dots )
-  grouped_indices_impl(groups$data, groups$groups)
+  .dots <- lazyeval::all_dots(..., .dots)
+  if (length(.dots) == 0L) {
+    return(rep(1L, nrow(.data)))
+  }
+  grouped_indices_grouped_df_impl(group_by_(.data, .dots = .dots))
 }
 
 #' @export

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -191,6 +191,28 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// grouped_indices_grouped_df_impl
+IntegerVector grouped_indices_grouped_df_impl(GroupedDataFrame gdf);
+RcppExport SEXP dplyr_grouped_indices_grouped_df_impl(SEXP gdfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< GroupedDataFrame >::type gdf(gdfSEXP);
+    rcpp_result_gen = Rcpp::wrap(grouped_indices_grouped_df_impl(gdf));
+    return rcpp_result_gen;
+END_RCPP
+}
+// group_size_grouped_cpp
+IntegerVector group_size_grouped_cpp(GroupedDataFrame gdf);
+RcppExport SEXP dplyr_group_size_grouped_cpp(SEXP gdfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< GroupedDataFrame >::type gdf(gdfSEXP);
+    rcpp_result_gen = Rcpp::wrap(group_size_grouped_cpp(gdf));
+    return rcpp_result_gen;
+END_RCPP
+}
 // resolve_vars
 SEXP resolve_vars(List new_groups, CharacterVector names);
 RcppExport SEXP dplyr_resolve_vars(SEXP new_groupsSEXP, SEXP namesSEXP) {
@@ -235,28 +257,6 @@ BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< DataFrame >::type df(dfSEXP);
     rcpp_result_gen = Rcpp::wrap(ungroup_grouped_df(df));
-    return rcpp_result_gen;
-END_RCPP
-}
-// grouped_indices_grouped_df_impl
-IntegerVector grouped_indices_grouped_df_impl(GroupedDataFrame gdf);
-RcppExport SEXP dplyr_grouped_indices_grouped_df_impl(SEXP gdfSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< GroupedDataFrame >::type gdf(gdfSEXP);
-    rcpp_result_gen = Rcpp::wrap(grouped_indices_grouped_df_impl(gdf));
-    return rcpp_result_gen;
-END_RCPP
-}
-// group_size_grouped_cpp
-IntegerVector group_size_grouped_cpp(GroupedDataFrame gdf);
-RcppExport SEXP dplyr_group_size_grouped_cpp(SEXP gdfSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< GroupedDataFrame >::type gdf(gdfSEXP);
-    rcpp_result_gen = Rcpp::wrap(group_size_grouped_cpp(gdf));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -249,18 +249,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// grouped_indices_impl
-IntegerVector grouped_indices_impl(DataFrame data, ListOf<Symbol> symbols);
-RcppExport SEXP dplyr_grouped_indices_impl(SEXP dataSEXP, SEXP symbolsSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< DataFrame >::type data(dataSEXP);
-    Rcpp::traits::input_parameter< ListOf<Symbol> >::type symbols(symbolsSEXP);
-    rcpp_result_gen = Rcpp::wrap(grouped_indices_impl(data, symbols));
-    return rcpp_result_gen;
-END_RCPP
-}
 // group_size_grouped_cpp
 IntegerVector group_size_grouped_cpp(GroupedDataFrame gdf);
 RcppExport SEXP dplyr_group_size_grouped_cpp(SEXP gdfSEXP) {

--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -33,60 +33,6 @@ IntegerVector grouped_indices_grouped_df_impl(GroupedDataFrame gdf) {
 }
 
 // [[Rcpp::export]]
-IntegerVector grouped_indices_impl(DataFrame data, ListOf<Symbol> symbols) {
-  int nsymbols = symbols.size();
-  if (nsymbols == 0)
-    return rep(1, data.nrows());
-  CharacterVector vars(nsymbols);
-  for (int i=0; i<nsymbols; i++) {
-    vars[i] = PRINTNAME(symbols[i]);
-
-    const char* name = vars[i];
-    SEXP v;
-    try {
-      v = data[name];
-    } catch (...) {
-      stop("unknown column '%s'", name);
-    }
-    if (!white_list(v) || TYPEOF(v) == VECSXP) {
-      stop("cannot group column %s, of class '%s'", name, get_single_class(v));
-    }
-  }
-
-  DataFrameVisitors visitors(data, vars);
-  ChunkIndexMap map(visitors);
-  int n = data.nrows();
-  train_push_back(map, n);
-
-  DataFrame labels = DataFrameSubsetVisitors(data, vars).subset(map, "data.frame");
-  IntegerVector labels_order = OrderVisitors(labels).apply();
-
-  labels = DataFrameSubsetVisitors(labels).subset(labels_order, "data.frame");
-
-  int ngroups = map.size();
-
-  IntegerVector res = no_init(n);
-
-  std::vector<const std::vector<int>* > chunks(ngroups);
-  ChunkIndexMap::const_iterator it = map.begin();
-  for (int i=0; i<ngroups; i++, ++it) {
-    chunks[i] = &it->second;
-  }
-
-  for (int i=0; i<ngroups; i++) {
-    int idx = labels_order[i];
-    const std::vector<int>& v = *chunks[idx];
-
-    int n_index = v.size();
-    for (int j=0; j<n_index; j++) {
-      res[ v[j] ] = i+1;
-    }
-  }
-
-  return res;
-}
-
-// [[Rcpp::export]]
 IntegerVector group_size_grouped_cpp(GroupedDataFrame gdf) {
   return Count().process(gdf);
 }


### PR DESCRIPTION
The implementation looks pretty similar to build_index_cpp(), I guess there's not much difference if we compute the index with a regular grouping operation.

The new implementation is a tad slower for `nycflights13::flights %>% group_indices(year, month, day)` (~95 ms vs. ~91 ms), I suspect this is because `group_by()` always computes labels. Do we need to care about that?

@hadley: PTAL.