### PR TITLE
Change references to functionmap2 to pkgapi

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     microbenchmark,
     ggplot2,
     mgcv,
+    pkgapi,
     Lahman (>= 3.0-1),
     nycflights13,
     rmarkdown,
@@ -130,4 +131,4 @@ Collate:
     'view.r'
     'zzz.r'
 RoxygenNote: 5.0.1.9000
-Roxygen: list(roclets = c("rd", "namespace", "collate", "functionmap2::api_roclet"))
+Roxygen: list(roclets = c("rd", "namespace", "collate", "pkgapi::api_roclet"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Suggests:
     microbenchmark,
     ggplot2,
     mgcv,
-    pkgapi,
     Lahman (>= 3.0-1),
     nycflights13,
     rmarkdown,


### PR DESCRIPTION
Since `functionmap2` was renamed to `pkgapi` https://github.com/r-pkgs/pkgapi/commit/b8342cc58a241dbb5ed6f2ccc779a7cb9dd97c18