### PR TITLE
Combine strips unknown classes. Support integer64.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,8 @@ Suggests:
     nycflights13,
     rmarkdown,
     covr,
-    dtplyr
+    dtplyr,
+    bit64
 VignetteBuilder: knitr
 LinkingTo: Rcpp (>= 0.12.0),
     BH (>= 1.58.0-1),

--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -10,11 +10,11 @@
 namespace dplyr {
 
   static inline bool is_class_known(SEXP x) {
-    Rcpp::CharacterVector known = Rcpp::CharacterVector::create(
+    CharacterVector known = CharacterVector::create(
       "POSIXct", "factor", "Date", "AsIs", "integer64", "table");
     int num_known = known.length();
     if (OBJECT(x)) {
-      Rcpp::CharacterVector classes(Rf_getAttrib(x, R_ClassSymbol));
+      CharacterVector classes(Rf_getAttrib(x, R_ClassSymbol));
       int num_classes = classes.length();
       for (int i=0;i<num_classes;i++) {
         for (int j=0;j<num_known;j++) {
@@ -454,7 +454,7 @@ namespace dplyr {
       if (Rf_inherits(model, "Date"))
         return new TypedCollecter<REALSXP>(n, get_date_classes());
       if (Rf_inherits(model, "integer64"))
-        return new TypedCollecter<REALSXP>(n, Rcpp::CharacterVector::create("integer64"));
+        return new TypedCollecter<REALSXP>(n, CharacterVector::create("integer64"));
       return new Collecter_Impl<REALSXP>(n);
     case CPLXSXP:
       return new Collecter_Impl<CPLXSXP>(n);
@@ -503,7 +503,7 @@ namespace dplyr {
       if (Rf_inherits(model, "Date"))
         return new TypedCollecter<REALSXP>(n, get_date_classes());
       if (Rf_inherits(model, "integer64"))
-        return new TypedCollecter<REALSXP>(n, Rcpp::CharacterVector::create("integer64"));
+        return new TypedCollecter<REALSXP>(n, CharacterVector::create("integer64"));
       return new Collecter_Impl<REALSXP>(n);
     case LGLSXP:
       return new Collecter_Impl<LGLSXP>(n);

--- a/tests/testthat/helper-combine.R
+++ b/tests/testthat/helper-combine.R
@@ -172,7 +172,8 @@ prepare_table_with_coercion_rules <- function() {
     num_with_class = structure(4.5, class = "num_with_class")
   )
 
-  special_non_vector_classes <- c("factor", "POSIXct", "Date", "table", "AsIs", "integer64")
+  special_non_vector_classes <- c("factor", "POSIXct", "Date",
+                                  "table", "AsIs", "integer64")
   pairs <- expand.grid(names(items), names(items))
   pairs$can_combine <- FALSE
   pairs$warning <- FALSE
@@ -202,7 +203,8 @@ prepare_table_with_coercion_rules <- function() {
       item1, item2,
       class1, class2,
       known_to_dplyr1, known_to_dplyr2,
-      can_be_combined = pairs$can_combine[i])
+      can_be_combined = pairs$can_combine[i]
+    )
 
     pairs$item_pair[[i]] <- list(item1, item2)
     pairs$result[i] <- combine_result(

--- a/tests/testthat/helper-combine.R
+++ b/tests/testthat/helper-combine.R
@@ -172,8 +172,9 @@ prepare_table_with_coercion_rules <- function() {
     num_with_class = structure(4.5, class = "num_with_class")
   )
 
-  special_non_vector_classes <- c("factor", "POSIXct", "Date",
-                                  "table", "AsIs", "integer64")
+  special_non_vector_classes <- c(
+    "factor", "POSIXct", "Date", "table", "AsIs", "integer64"
+  )
   pairs <- expand.grid(names(items), names(items))
   pairs$can_combine <- FALSE
   pairs$warning <- FALSE

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -160,5 +160,14 @@ test_that("combine works with NA and complex (#2203)", {
   expect_equal(works3, expected_result)
 })
 
+test_that("combine works with integer64", {
+  if (!test_srcs$has("bit64"))
+    skip("No bit64")
+  expect_equal(combine(bit64::as.integer64(2^34),
+                       bit64::as.integer64(2^35)),
+               c(bit64::as.integer64(2^34),
+                 bit64::as.integer64(2^35)))
+})
+
 # Uses helper-combine.R
 combine_coercion_types()

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -160,10 +160,11 @@ test_that("combine works with NA and complex (#2203)", {
   expect_equal(works3, expected_result)
 })
 
-test_that("combine works with integer64", {
+test_that("combine works with integer64 (#1092)", {
   expect_equal(
     combine(bit64::as.integer64(2^34), bit64::as.integer64(2^35)),
-            c(bit64::as.integer64(2^34), bit64::as.integer64(2^35)))
+    bit64::as.integer64(c(2^34, 2^35))
+  )
 })
 
 # Uses helper-combine.R

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -161,12 +161,9 @@ test_that("combine works with NA and complex (#2203)", {
 })
 
 test_that("combine works with integer64", {
-  if (!test_srcs$has("bit64"))
-    skip("No bit64")
-  expect_equal(combine(bit64::as.integer64(2^34),
-                       bit64::as.integer64(2^35)),
-               c(bit64::as.integer64(2^34),
-                 bit64::as.integer64(2^35)))
+  expect_equal(
+    combine(bit64::as.integer64(2^34), bit64::as.integer64(2^35)),
+            c(bit64::as.integer64(2^34), bit64::as.integer64(2^35)))
 })
 
 # Uses helper-combine.R


### PR DESCRIPTION
This commit closes #2406.

- If we `collect` objects of unknown classes there is risk of losing attributes, so we raise a warning unless we know it is safe.
- `bit64::integer64` is now supported by `dplyr::combine` and `dplyr::bind_rows` (partially deals with https://github.com/hadley/dplyr/issues/1092)
- Tests updated to reflect current status

