### PR TITLE
Allow mutation within group_by()

### DIFF
--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -105,7 +105,26 @@ sql_build.op_head <- function(op, con, ...) {
 
 #' @export
 sql_build.op_group_by <- function(op, con, ...) {
-  sql_build(op$x, con, ...)
+  vars <- op_vars(op$x)
+  new_groups <- lazyeval::all_dots(op$dots, ...)
+
+  is_name <- vapply(new_groups, function(x) is.name(x$expr), logical(1))
+  diff_name <-
+    sapply(new_groups, function(x) deparse(x$expr)) != names(new_groups)
+  needs_mutate <- diff_name | !is_name
+
+  if (any(needs_mutate)) {
+    new_vars <- translate_sql_(new_groups[needs_mutate], con, vars)
+    old_vars <- ident(setdiff(vars, names(new_vars)))
+    sql <- select_query(
+      sql_build(op$x, con),
+      select = c.sql(old_vars, new_vars, con = con)
+    )
+  } else {
+    sql <- sql_build(op$x, con, ...)
+  }
+
+  sql
 }
 
 #' @export


### PR DESCRIPTION
Modify `sql_build.op_group_by()` to build an explicit SELECT statement that includes mutation of columns. When there's no mutation needed, follow the default behavior by returning the original query/table.

Related to #2422 