### PR TITLE
fix translate sql

### DIFF
--- a/R/translate-sql-base.r
+++ b/R/translate-sql-base.r
@@ -211,7 +211,7 @@ base_win <- sql_translator(
     )
   },
   lag = function(x, n = 1L, default = NA, order = NULL) {
-    over(
+    win_over(
       build_sql("LAG", list(x, as.integer(n), default)),
       win_current_group(),
       order %||% win_current_order()


### PR DESCRIPTION
In commit 421b569 the function `win_over()` was added. Today, I used `lag()` with `src_postgres()` on the master and I got the following error:

    Error in lag(value, order = "date") : could not find function "over"

When I looked in translate-base-sql.R, it looks like you changed all of the other base_win functions to use `win_over()` but you might have just missed `lag()`.