### PR TITLE
minor documentation edit

### DIFF
--- a/R/recode.R
+++ b/R/recode.R
@@ -7,7 +7,9 @@
 #'
 #' @param .x A vector to modify
 #' @param ... Replacements. These should be named for character and factor
-#'   `.x`, and can be named for numeric `.x`.
+#'   `.x`, and can be named for numeric `.x`. The argument names should be the
+#'   current values to be replaced, and the argument values should be the new
+#'   (replacement) values.
 #'
 #'   All replacements must be the same type, and must have either
 #'   length one or the same length as x.


### PR DESCRIPTION
Make the description of the `...` argument in `recode` more clear.
Currently the documentation does not state whether the names or values of the arguments are the replacement, leaving the reader to infer it from the examples.
This is particularly confusing since `forcats::fct_recode` uses the opposite convention (names are replacements, values are the values to be replaced).