### PR TITLE
Cleanup active environment

### DIFF
--- a/tests/testthat/helper-hybrid.R
+++ b/tests/testthat/helper-hybrid.R
@@ -40,10 +40,13 @@ expect_not_hybrid_error_ <- function(expr, ..., error) {
     error)
 }
 
-expect_environments_empty <- function(x) {
+expect_environments_clean <- function(x, stop_env = parent.frame()) {
   if (!is.environment(x)) x <- environment(x)
-  if (isNamespace(x)) return()
+  if (identical(x, stop_env)) return()
 
-  expect_equal(ls(x, all.names = TRUE), character())
-  expect_environments_empty(parent.env(x))
+  obj_names <- ls(x, all.names = TRUE)
+  objs <- mget(obj_names, x)
+  lapply(objs, expect_is, "environment")
+
+  expect_environments_clean(parent.env(x), stop_env = stop_env)
 }

--- a/tests/testthat/helper-hybrid.R
+++ b/tests/testthat/helper-hybrid.R
@@ -39,3 +39,11 @@ expect_not_hybrid_error_ <- function(expr, ..., error) {
     without_hybrid_(expr, ...),
     error)
 }
+
+expect_environments_empty <- function(x) {
+  if (!is.environment(x)) x <- environment(x)
+  if (isNamespace(x)) return()
+
+  expect_equal(ls(x, all.names = TRUE), character())
+  expect_environments_empty(parent.env(x))
+}

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1,5 +1,15 @@
 context("hybrid")
 
+test_that("hybrid evaluation environment is cleaned up (#2358)", {
+  df <-
+    data_frame(x = 1) %>%
+    mutate(f = list(function(){})) %>%
+    mutate(g = list(~.))
+
+  expect_environments_empty(df$f[[1]])
+  expect_environments_empty(df$g[[1]])
+})
+
 test_that("n() and n_distinct() work", {
   check_hybrid_result(
     n(), a = 1:5,

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1,13 +1,13 @@
 context("hybrid")
 
 test_that("hybrid evaluation environment is cleaned up (#2358)", {
-  df <-
-    data_frame(x = 1) %>%
-    mutate(f = list(function(){})) %>%
-    mutate(g = list(~.))
+  # Can't use pipe here, f and g should have top-level parent.env()
+  df <- data_frame(x = 1)
+  df <- mutate(df, f = list(function(){}))
+  df <- mutate(df, g = list(~.))
 
-  expect_environments_empty(df$f[[1]])
-  expect_environments_empty(df$g[[1]])
+  expect_environments_clean(df$f[[1]])
+  expect_environments_clean(df$g[[1]])
 })
 
 test_that("n() and n_distinct() work", {


### PR DESCRIPTION
to avoid leaking of broken bindings via environments of function objects or formulas.

Closes #2358.

@hadley: PTAL.