### PR TITLE
Fix segfault when using min_rank("string") in hybrid evaluation

### DIFF
--- a/R/top-n.R
+++ b/R/top-n.R
@@ -43,7 +43,7 @@ top_n <- function(x, n, wt) {
     wt <- substitute(wt)
   }
 
-  stopifnot(is.numeric(n), length(n) == 1)
+  stopifnot(is.numeric(n), length(n) == 1, is.name(wt))
   if (n > 0) {
     call <- substitute(
       filter(x, min_rank(desc(wt)) <= n),

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -39,17 +39,17 @@ Result* row_number_prototype(SEXP call, const ILazySubsets& subsets, int nargs) 
     if (subsets.count(data)) data = subsets.get_variable(data);
     else return 0;
   }
-  if (Rf_length(data) == subsets.nrows()) {
-    switch (TYPEOF(data)) {
-    case INTSXP:
-      return new RowNumber<INTSXP,true>(data);
-    case REALSXP:
-      return new RowNumber<REALSXP,true>(data);
-    case STRSXP:
-      return new RowNumber<STRSXP,true>(data);
-    default:
-      break;
-    }
+  if (subsets.nrows() != Rf_length(data)) return 0;
+
+  switch (TYPEOF(data)) {
+  case INTSXP:
+    return new RowNumber<INTSXP,true>(data);
+  case REALSXP:
+    return new RowNumber<REALSXP,true>(data);
+  case STRSXP:
+    return new RowNumber<STRSXP,true>(data);
+  default:
+    break;
   }
   // we don't know how to handle it.
   return 0;
@@ -134,6 +134,8 @@ Result* rank_impl_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     if (subsets.count(data)) data = subsets.get_variable(data);
     else return 0;
   }
+  if (subsets.nrows() != Rf_length(data)) return 0;
+
   switch (TYPEOF(data)) {
   case INTSXP:
     return new Rank_Impl<INTSXP,  Increment, true>(data);

--- a/tests/testthat/helper-hybrid.R
+++ b/tests/testthat/helper-hybrid.R
@@ -1,11 +1,19 @@
+expect_predicate <- function(actual, expected) {
+  if (is.function(expected)) {
+    expect_true(expected(actual))
+  } else {
+    expect_identical(actual, expected)
+  }
+}
+
 check_hybrid_result <- function(expr, ..., expected, test_eval = TRUE) {
   check_hybrid_result_(lazyeval::f_capture(expr), ..., expected = expected, test_eval = test_eval)
 }
 
 check_hybrid_result_ <- function(expr, ..., expected, test_eval) {
-  expect_error(expect_identical(with_hybrid_(expr, ...), expected), NA)
+  expect_error(expect_predicate(with_hybrid_(expr, ...), expected), NA)
   if (test_eval) {
-    expect_identical(eval_dots_(expr, ...), expected)
+    expect_predicate(eval_dots_(expr, ...), expected)
   }
 }
 
@@ -14,9 +22,9 @@ check_not_hybrid_result <- function(expr, ..., expected, test_eval = TRUE) {
 }
 
 check_not_hybrid_result_ <- function(expr, ..., expected, test_eval) {
-  expect_error(expect_identical(without_hybrid_(expr, ...), expected), NA)
+  expect_error(expect_predicate(without_hybrid_(expr, ...), expected), NA)
   if (test_eval) {
-    expect_identical(eval_dots_(expr, ...), expected)
+    expect_predicate(eval_dots_(expr, ...), expected)
   }
 }
 
@@ -27,7 +35,8 @@ expect_hybrid_error <- function(expr, ..., error) {
 expect_hybrid_error_ <- function(expr, ..., error) {
   expect_error(
     with_hybrid_(expr, ...),
-    error)
+    error
+  )
 }
 
 expect_not_hybrid_error <- function(expr, ..., error) {
@@ -37,5 +46,6 @@ expect_not_hybrid_error <- function(expr, ..., error) {
 expect_not_hybrid_error_ <- function(expr, ..., error) {
   expect_error(
     without_hybrid_(expr, ...),
-    error)
+    error
+  )
 }

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -568,7 +568,7 @@ test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and 
   check_hybrid_result(
     list(row_number()), a = 1:5,
     expected = list(1:5),
-                test_eval = FALSE
+    test_eval = FALSE
   )
   check_hybrid_result(
     list(row_number(a)), a = 5:1,
@@ -614,6 +614,31 @@ test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and 
   expect_not_hybrid_error(
     ntile(a, 2, 1), a = 5:1,
     error = "unused argument"
+  )
+
+  check_not_hybrid_result(
+    row_number("a"), a = 5:1,
+    expected = 1L
+  )
+  check_not_hybrid_result(
+    min_rank("a"), a = 5:1,
+    expected = 1L
+  )
+  check_not_hybrid_result(
+    percent_rank("a"), a = 5:1,
+    expected = is.nan
+  )
+  check_not_hybrid_result(
+    cume_dist("a"), a = 5:1,
+    expected = 1
+  )
+  check_not_hybrid_result(
+    dense_rank("a"), a = 5:1,
+    expected = 1L
+  )
+  check_not_hybrid_result(
+    ntile("a", 2), a = 5:1,
+    expected = 1L
   )
 
   skip("Currently failing (constfold)")

--- a/tests/testthat/test-top-n.R
+++ b/tests/testthat/test-top-n.R
@@ -5,3 +5,11 @@ test_that("top_n returns n rows", {
   top_four <- test_df %>% top_n(4, y)
   expect_equal(dim(top_four), c(4, 2))
 })
+
+test_that("top_n errs if wt argument is not a symbol (#2279)", {
+  expect_error(
+    data.frame(x = 1:10) %>% top_n(10, "x"),
+    "is.name",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
also check arguments in top_n().

Fixes #2279.

@hadley: PTAL.