### PR TITLE
Allow one join suffix to be the empty string

### DIFF
--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -151,6 +151,49 @@ test_that("can control suffixes with suffix argument", {
   expect_named(j4, c("x", "z1", "z2"))
 })
 
+test_that("can handle empty string in suffix argument, left side (#2228, #2182, #2007)", {
+  j1 <- inner_join(e, f, "x", suffix = c("", "2"))
+  j2 <- left_join(e, f, "x", suffix = c("", "2"))
+  j3 <- right_join(e, f, "x", suffix = c("", "2"))
+  j4 <- full_join(e, f, "x", suffix = c("", "2"))
+
+  expect_named(j1, c("x", "z", "z2"))
+  expect_named(j2, c("x", "z", "z2"))
+  expect_named(j3, c("x", "z", "z2"))
+  expect_named(j4, c("x", "z", "z2"))
+})
+
+test_that("can handle empty string in suffix argument, right side (#2228, #2182, #2007)", {
+  j1 <- inner_join(e, f, "x", suffix = c("1", ""))
+  j2 <- left_join(e, f, "x", suffix = c("1", ""))
+  j3 <- right_join(e, f, "x", suffix = c("1", ""))
+  j4 <- full_join(e, f, "x", suffix = c("1", ""))
+
+  expect_named(j1, c("x", "z1", "z"))
+  expect_named(j2, c("x", "z1", "z"))
+  expect_named(j3, c("x", "z1", "z"))
+  expect_named(j4, c("x", "z1", "z"))
+})
+
+test_that("disallow empty string in both sides of suffix argument (#2228)", {
+  expect_error(
+    inner_join(e, f, "x", suffix = c("", "")),
+    "Cannot use empty string for both x and y suffixes"
+  )
+  expect_error(
+    left_join(e, f, "x", suffix = c("", "")),
+    "Cannot use empty string for both x and y suffixes"
+  )
+  expect_error(
+    right_join(e, f, "x", suffix = c("", "")),
+    "Cannot use empty string for both x and y suffixes"
+  )
+  expect_error(
+    full_join(e, f, "x", suffix = c("", "")),
+    "Cannot use empty string for both x and y suffixes"
+  )
+})
+
 test_that("inner_join does not segfault on NA in factors (#306)", {
   a <- data.frame(x = c("p", "q", NA), y = c(1, 2, 3), stringsAsFactors = TRUE)
   b <- data.frame(x = c("p", "q", "r"), z = c(4, 5, 6), stringsAsFactors = TRUE)
@@ -634,32 +677,4 @@ test_that("left_join handles mix of encodings in column names (#1571)", {
   expect_equal(res$baz, 1:6)
   expect_equal(res[["l\u00f8penummer"]], 1:6)
 
-})
-
-test_that("can handle empty string in suffix argument, left side (#2228, #2182, #2007)", {
-  skip("not yet resolved, would cause stack overflow")
-
-  j1 <- inner_join(e, f, "x", suffix = c("", "2"))
-  j2 <- left_join(e, f, "x", suffix = c("", "2"))
-  j3 <- right_join(e, f, "x", suffix = c("", "2"))
-  j4 <- full_join(e, f, "x", suffix = c("", "2"))
-
-  expect_named(j1, c("x", "z", "z2"))
-  expect_named(j2, c("x", "z", "z2"))
-  expect_named(j3, c("x", "z", "z2"))
-  expect_named(j4, c("x", "z", "z2"))
-})
-
-test_that("can handle empty string in suffix argument, right side (#2228, #2182, #2007)", {
-  skip("not yet resolved, would cause stack overflow")
-
-  j1 <- inner_join(e, f, "x", suffix = c("1", ""))
-  j2 <- left_join(e, f, "x", suffix = c("1", ""))
-  j3 <- right_join(e, f, "x", suffix = c("1", ""))
-  j4 <- full_join(e, f, "x", suffix = c("1", ""))
-
-  expect_named(j1, c("x", "z1", "z"))
-  expect_named(j2, c("x", "z1", "z"))
-  expect_named(j3, c("x", "z1", "z"))
-  expect_named(j4, c("x", "z1", "z"))
 })


### PR DESCRIPTION
Avoids endless loop.

Fixes #2228.

@hadley: PTAL.