### PR TITLE
Explicitly reject data frame columns in bind_rows()

### DIFF
--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -458,6 +458,9 @@ namespace dplyr {
       if (Rf_inherits(model, "POSIXlt")) {
         stop("POSIXlt not supported");
       }
+      if (Rf_inherits(model, "data.frame")) {
+        stop("Columns of class data.frame not supported");
+      }
       return new Collecter_Impl<VECSXP>(n);
     default:
       break;

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -416,3 +416,18 @@ test_that("bind_rows rejects POSIXlt columns (#1789)", {
   df$y <- as.POSIXlt(df$x)
   expect_error(bind_rows(df, df), "not supported")
 })
+
+test_that("bind_rows rejects data frame columns (#2015)", {
+  df <- list(
+    x = 1:10,
+    y = data.frame(a = 1:10, y = 1:10)
+  )
+  class(df) <- "data.frame"
+  attr(df, "row.names") <- .set_row_names(10)
+
+  expect_error(
+    dplyr::bind_rows(df, df),
+    "Columns of class data.frame not supported",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
Not checking other verbs yet.

Fixes #2015.

@hadley: PTAL.