### PR TITLE
Refactor language tests

### DIFF
--- a/tests/testthat/helper-encoding.R
+++ b/tests/testthat/helper-encoding.R
@@ -1,6 +1,29 @@
-lang_strings <- c(
-  de = "Gl\u00fcck",
-  cn = "\u5e78\u798f",
-  ru = "\u0441\u0447\u0430\u0441\u0442\u044c\u0435",
-  ko = "\ud589\ubcf5"
-)
+get_lang_strings <- function() {
+  lang_strings <- c(
+    de = "Gl\u00fcck",
+    cn = "\u5e78\u798f",
+    ru = "\u0441\u0447\u0430\u0441\u0442\u044c\u0435",
+    ko = "\ud589\ubcf5"
+  )
+
+  native_lang_strings <- enc2native(lang_strings)
+
+  same <- (lang_strings == native_lang_strings)
+
+  list(
+    same = lang_strings[same],
+    different = lang_strings[!same]
+  )
+}
+
+get_native_lang_string <- function() {
+  lang_strings <- get_lang_strings()
+  if (length(lang_strings$same) == 0) testthat::skip("No native language string available")
+  lang_strings$same[[1L]]
+}
+
+get_alien_lang_string <- function() {
+  lang_strings <- get_lang_strings()
+  if (length(lang_strings$different) == 0) testthat::skip("No alien language string available")
+  lang_strings$different[[1L]]
+}

--- a/tests/testthat/helper-encoding.R
+++ b/tests/testthat/helper-encoding.R
@@ -27,3 +27,26 @@ get_alien_lang_string <- function() {
   if (length(lang_strings$different) == 0) testthat::skip("No alien language string available")
   lang_strings$different[[1L]]
 }
+
+with_non_utf8_encoding <- function(code) {
+  old_encoding <- set_non_utf8_encoding()
+  on.exit(set_encoding(old_encoding), add = TRUE)
+  code
+}
+
+set_non_utf8_encoding <- function() {
+  if (.Platform$OS.type == "windows") return(NULL)
+  tryCatch(
+    locale <- set_encoding("en_US.ISO88591"),
+    warning = function(e) {
+      testthat::skip("Cannot set latin-1 encoding")
+    }
+  )
+  locale
+}
+
+set_encoding <- function(encoding) {
+  locale <- Sys.getlocale("LC_CTYPE")
+  Sys.setlocale("LC_CTYPE", encoding)
+  locale
+}

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -242,18 +242,20 @@ test_that("group_by supports column (#1012)", {
 })
 
 test_that(paste0("group_by handles encodings for native strings (#1507)"), {
-  special <- get_native_lang_string()
+  with_non_utf8_encoding({
+    special <- get_native_lang_string()
 
-  df <- data.frame(x = 1:3, Eng = 2:4)
+    df <- data.frame(x = 1:3, Eng = 2:4)
 
-  for (names_converter in c(enc2native, enc2utf8)) {
-    for (dots_converter in c(enc2native, enc2utf8)) {
-      names(df) <- names_converter(c(special, "Eng"))
-      res <- group_by_(df, .dots = dots_converter(special))
-      expect_equal(names(res), names(df))
-      expect_groups(res, special)
+    for (names_converter in c(enc2native, enc2utf8)) {
+      for (dots_converter in c(enc2native, enc2utf8)) {
+        names(df) <- names_converter(c(special, "Eng"))
+        res <- group_by_(df, .dots = dots_converter(special))
+        expect_equal(names(res), names(df))
+        expect_groups(res, special)
+      }
     }
-  }
+  })
 })
 
 test_that("group_by fails gracefully on raw columns (#1803)", {

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -241,23 +241,20 @@ test_that("group_by supports column (#1012)", {
   expect_equal(attr(g1, "vars"), attr(g4, "vars"))
 })
 
-for (special in lang_strings) {
-  if (enc2native(special) == special) {
-    test_that(paste0("group_by handles encodings for ", special, " (#1507)"), {
+test_that(paste0("group_by handles encodings for native strings (#1507)"), {
+  special <- get_native_lang_string()
 
-      df <- data.frame(x = 1:3, Eng = 2:4)
+  df <- data.frame(x = 1:3, Eng = 2:4)
 
-      for (names_converter in c(enc2native, enc2utf8)) {
-        for (dots_converter in c(enc2native, enc2utf8)) {
-          names(df) <- names_converter(c(special, "Eng"))
-          res <- group_by_(df, .dots = dots_converter(special))
-          expect_equal(names(res), names(df))
-          expect_groups(res, special)
-        }
-      }
-    })
+  for (names_converter in c(enc2native, enc2utf8)) {
+    for (dots_converter in c(enc2native, enc2utf8)) {
+      names(df) <- names_converter(c(special, "Eng"))
+      res <- group_by_(df, .dots = dots_converter(special))
+      expect_equal(names(res), names(df))
+      expect_groups(res, special)
+    }
   }
-}
+})
 
 test_that("group_by fails gracefully on raw columns (#1803)", {
   df <- data_frame(a = 1:3, b = as.raw(1:3))

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -664,17 +664,19 @@ test_that("inner join not crashing (#1559)", {
 })
 
 test_that("left_join handles mix of encodings in column names (#1571)", {
+  with_non_utf8_encoding({
+    special <- get_native_lang_string()
 
-  df1 <- tibble::data_frame(x = 1:6, foo = 1:6)
-  names(df1)[1] <- "l\u00f8penummer"
+    df1 <- data_frame(x = 1:6, foo = 1:6)
+    names(df1)[1] <- special
 
-  df2 <- tibble::data_frame(x = 1:6, baz = 1:6)
-  names(df2)[1] <- iconv("l\u00f8penummer", from = "UTF-8", to = "latin1")
+    df2 <- data_frame(x = 1:6, baz = 1:6)
+    names(df2)[1] <- enc2native(special)
 
-  expect_message(res <- left_join(df1, df2))
-  expect_equal(names(res), c("l\u00f8penummer", "foo", "baz"))
-  expect_equal(res$foo, 1:6)
-  expect_equal(res$baz, 1:6)
-  expect_equal(res[["l\u00f8penummer"]], 1:6)
-
+    expect_message(res <- left_join(df1, df2), special, fixed = TRUE)
+    expect_equal(names(res), c(special, "foo", "baz"))
+    expect_equal(res$foo, 1:6)
+    expect_equal(res$baz, 1:6)
+    expect_equal(res[[special]], 1:6)
+  })
 })


### PR DESCRIPTION
- run in latin1 locale on Linux/OS X for now
- infrastructure to run test with one "complicated" string