### PR TITLE
Combine character and factor show warning. Closes #2317

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -347,6 +347,9 @@
 
 * `combine()` accepts `NA` values (#2203, @zeehio)
 
+* `combine()` and `bind_rows()` with character and factor types now always warn
+  about the coercion to character (#2317, @zeehio)
+
 # dplyr 0.5.0
 
 ## Breaking changes

--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -228,6 +228,7 @@ namespace dplyr {
 
     void collect_factor(const SlicingIndex& index, IntegerVector source) {
       CharacterVector levels = get_levels(source);
+      Rf_warning("binding character and factor vector, coercing into character vector");
       for (int i=0; i<index.size(); i++) {
         if (source[i] == NA_INTEGER) {
           data[index[i]] = NA_STRING;
@@ -431,7 +432,6 @@ namespace dplyr {
       // we however do not assume that they are in the same order
       IntegerVector source(v);
       CharacterVector levels = get_levels(source);
-
       SEXP* levels_ptr = Rcpp::internal::r_vector_start<STRSXP>(levels);
       int* source_ptr = Rcpp::internal::r_vector_start<INTSXP>(source);
       for (int i=0; i<index.size(); i++) {

--- a/tests/testthat/helper-combine.R
+++ b/tests/testthat/helper-combine.R
@@ -82,7 +82,8 @@ give_a_warning <- function(item1, item2,
   }
 
   # factor and character give a warning when combined (coercion to character)
-  if (class1 == "factor" && class2 == "character") {
+  if ((class1 == "factor" && class2 == "character") ||
+      (class1 == "character" && class2 == "factor")) {
     return(TRUE)
   }
 


### PR DESCRIPTION
When we collect a factor into a character vector we should warn as well of the coercion of the factor to a character for consistency. This PR adds the warning and fixes the test case.

Closes #2317 