### PR TITLE
Prevent the sql optimizer from optimizing empty clauses

### DIFF
--- a/R/sql-optimise.R
+++ b/R/sql-optimise.R
@@ -29,7 +29,9 @@ sql_optimise.select_query <- function(x, con = NULL, ...) {
   outer <- select_query_clauses(x)
   inner <- select_query_clauses(from)
 
-  if (min(outer) > max(inner)) {
+  if (length(outer) > 0 &&
+      length(inner) > 0 &&
+      min(outer) > max(inner)) {
     from[as.character(outer)] <- x[as.character(outer)]
     from
   } else {


### PR DESCRIPTION
While using `add_op_single`, one can define a `SELECT` query that uses `SELECT = c("*")` and no other clause. When this happens, the SQL optimizer in dplyr ends up getting an empty vector during `select_query_clauses` since no other clause is defined. The fix is to only apply the optimization when `outer` and `from` have entries.

The actual repro would be to:

```{r}
install.packages(`sparklyr`)
library(sparklyr)
library(dplyr)

spark_install()
sc <- spark_connect(master = "local")
iris_tbl <- copy_to(sc, iris)
iris_tbl %>% sample_n(10)
spark_disconnect(sc)
```

with output:

```
Error in if (min(outer) > max(inner)) { : 
  missing value where TRUE/FALSE needed
In addition: Warning message:
In max(integer(0), na.rm = FALSE) :
  no non-missing arguments to max; returning -Inf
Called from: sql_optimise.select_query(qry, con = con, ...)
```