### PR TITLE
Adds mutate support to reference new left-side expressions in lazy-tbl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr 0.5.0.9000
 
+* The SQL translation of `mutate()` now accepts references to new
+  expressions (#2481).
+
 * `bind_cols()` now calls `tibble::repair_names()` to ensure that all
   names are unique (#2248).
 

--- a/R/tbl-lazy.R
+++ b/R/tbl-lazy.R
@@ -81,6 +81,13 @@ summarise_.tbl_lazy <- function(.data, ..., .dots) {
 mutate_.tbl_lazy <- function(.data, ..., .dots) {
   dots <- lazyeval::all_dots(.dots, ..., all_named = TRUE)
   dots <- partial_eval(dots, vars = op_vars(.data))
+  flat <- unlist(lapply(dots, function(e) as.list(e)))
+
+  while(length(dots) > 1 && any(flat %in% names(dots))) {
+    i <- first(which(!is.na(match(names(dots), flat))))
+    .data <- dplyr::add_op_single("mutate", .data, dots = dots[i])
+    dots[[i]] <- NULL
+  }
 
   add_op_single("mutate", .data, dots = dots)
 }

--- a/tests/testthat/test-sql-render.R
+++ b/tests/testthat/test-sql-render.R
@@ -100,6 +100,16 @@ test_that("mutate overwrites previous variables", {
   expect_equal(df$x, 1:5 + 2)
 })
 
+test_that("mutate supports referencing new left-side columns", {
+  df <- memdb_frame(x = 1:5) %>%
+    mutate(y = x + 1, z = y + 1) %>%
+    collect()
+
+  expect_equal(names(df), c("x", "y", "z"))
+  expect_equal(df$y, 1:5 + 1)
+  expect_equal(df$z, 1:5 + 2)
+})
+
 test_that("sequence of operations work", {
   out <- memdb_frame(x = c(1, 2, 3, 4)) %>%
     select(y = x) %>%


### PR DESCRIPTION
See https://github.com/hadley/dplyr/issues/2481. This adds support for:

```
df <- memdb_frame(x = runif(100), y = runif(100))
df %>% mutate(x1 = x, x2 = x1)
```

Notice that this won't work in `data.frame` nor `lazy-tbl`:

```
df <- memdb_frame(x = runif(100), y = runif(100))
df %>% mutate(x2 = x1, x1 = x)
```