### PR TITLE
Add difftime support to combine and bind_rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -350,6 +350,8 @@
 * `combine()` and `bind_rows()` with character and factor types now always warn
   about the coercion to character (#2317, @zeehio)
 
+* `combine()` and `bind_rows()` accept `difftime` objects.
+
 # dplyr 0.5.0
 
 ## Breaking changes

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -457,3 +457,11 @@ test_that("bind_rows rejects data frame columns (#2015)", {
     fixed = TRUE
   )
 })
+
+test_that("bind_rows accepts difftime objects", {
+  df1 <- data.frame(x = as.difftime(1, units = "hours"))
+  df2 <- data.frame(x = as.difftime(1, units = "mins"))
+  res <- bind_rows(df1, df2)
+  expect_equal(res$x,
+               c(df1$x, df2$x))
+})

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -462,6 +462,5 @@ test_that("bind_rows accepts difftime objects", {
   df1 <- data.frame(x = as.difftime(1, units = "hours"))
   df2 <- data.frame(x = as.difftime(1, units = "mins"))
   res <- bind_rows(df1, df2)
-  expect_equal(res$x,
-               c(df1$x, df2$x))
+  expect_equal(res$x, as.difftime(c(3600, 60), units = "secs"))
 })

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -167,5 +167,29 @@ test_that("combine works with integer64 (#1092)", {
   )
 })
 
+test_that("combine works with difftime", {
+  expect_equal(
+    combine(as.difftime(1, units = "mins"), as.difftime(1, units = "hours")),
+    as.difftime(c(60, 3600), units = "secs")
+  )
+  expect_equal(
+    combine(as.difftime(1, units = "secs"), as.difftime(1, units = "secs")),
+    as.difftime(c(1, 1), units = "secs")
+  )
+  expect_equal(
+    combine(as.difftime(1, units = "days"), as.difftime(1, units = "secs")),
+    as.difftime(c(24*60*60, 1), units = "secs")
+  )
+  expect_equal(
+    combine(as.difftime(2, units = "weeks"), as.difftime(1, units = "secs")),
+    as.difftime(c(2*7*24*60*60, 1), units = "secs")
+  )
+  expect_equal(
+    combine(as.difftime(2, units = "weeks"), as.difftime(3, units = "weeks")),
+    as.difftime(c(2,3), units = "weeks")
+  )
+
+})
+
 # Uses helper-combine.R
 combine_coercion_types()


### PR DESCRIPTION
- We are already supporting mutate with difftime variables.
- I'm preparing a PR to make mutate use `Collecter.h` (sharing the coercion rules and algorithm used by `combine` and `bind_rows`).
- To preserve backwards compatibility in mutate with difftime objects I need `Collecter.h` to support `difftime` objects.

This is the first out of two PRs for #1892. The next PR will depend on this one but this can be reviewed (and merged) already (improves dplyr compatibility).
