### PR TITLE
Make mutate use collecter h

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Suggests:
     rmarkdown,
     covr,
     dtplyr,
-    bit64
+    bit64,
+    hms
 VignetteBuilder: knitr
 LinkingTo: Rcpp (>= 0.12.0),
     BH (>= 1.58.0-1),

--- a/NEWS.md
+++ b/NEWS.md
@@ -352,6 +352,9 @@
 
 * `combine()` and `bind_rows()` accept `difftime` objects.
 
+* `mutate` coerces results from grouped dataframes accepting combinable data
+  types (such as `integer` and `numeric`). (#1892, @zeehio)
+
 # dplyr 0.5.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -350,6 +350,8 @@
 * `combine()` and `bind_rows()` with character and factor types now always warn
   about the coercion to character (#2317, @zeehio)
 
+* `combine()` and `bind_rows()` accept `difftime` objects.
+
 # dplyr 0.5.0
 
 ## Breaking changes

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -11,6 +11,7 @@
 
 #include <dplyr/vector_class.h>
 #include <dplyr/checks.h>
+#include <dplyr/Collecter.h>
 
 namespace dplyr {
 
@@ -20,23 +21,28 @@ namespace dplyr {
     virtual SEXP collect() = 0;
   };
 
-  template <int RTYPE, typename Data, typename Subsets>
+  template <typename Data, typename Subsets>
   class GathererImpl : public Gatherer {
   public:
-    typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
     typedef GroupedCallProxy<Data,Subsets> Proxy;
 
-    GathererImpl(RObject& first, SlicingIndex& indices, Proxy& proxy_, const Data& gdf_, int first_non_na_) :
-      gdf(gdf_), proxy(proxy_), data(gdf.nrows(), Vector<RTYPE>::get_na()), first_non_na(first_non_na_)
+    GathererImpl(RObject& first, SlicingIndex& indices, Proxy& proxy_, const Data& gdf_, int first_non_na_, const SymbolString& name_) :
+      gdf(gdf_), proxy(proxy_), first_non_na(first_non_na_), name(name_)
     {
+      coll = collecter(first, gdf.nrows());
       if (first_non_na < gdf.ngroups())
         grab(first, indices);
-      copy_most_attributes(data, first);
+    }
+
+    ~GathererImpl() {
+      if (coll != 0) {
+        delete coll;
+      }
     }
 
     SEXP collect() {
       int ngroups = gdf.ngroups();
-      if (first_non_na == ngroups) return data;
+      if (first_non_na == ngroups) return coll->get();
       typename Data::group_iterator git = gdf.group_begin();
       int i = 0;
       for (; i<first_non_na; i++) ++git;
@@ -47,52 +53,70 @@ namespace dplyr {
         Shield<SEXP> subset(proxy.get(indices));
         grab(subset, indices);
       }
-      return data;
+      return coll->get();
     }
 
   private:
 
     inline void grab(SEXP subset, const SlicingIndex& indices) {
       int n = Rf_length(subset);
-      if (is<LogicalVector>(subset) && all(is_na(LogicalVector(subset))).is_true()) {
-        grab_rep(Vector<RTYPE>::get_na(), indices);
+      if (n == indices.size()) {
+        grab_along(subset, indices);
+      } else if (n == 1) {
+        grab_rep(subset, indices);
+      } else if (Rf_isNull(subset)) {
+        stop("incompatible types (NULL), expecting %s", coll->describe());
       } else {
-        check_type(subset);
-        if (n == indices.size()) {
-          grab_along(subset, indices);
-        } else if (n == 1) {
-          grab_rep(Rcpp::internal::r_vector_start<RTYPE>(subset)[0], indices);
-        } else {
-          check_length(n, indices.size(), "the group size");
-        }
+        check_length(n, indices.size()  , "the group size");
       }
+
     }
 
     void grab_along(SEXP subset, const SlicingIndex& indices) {
-      int n = indices.size();
-      STORAGE* ptr = Rcpp::internal::r_vector_start<RTYPE>(subset);
-      for (int j=0; j<n; j++) {
-        data[ indices[j] ] = ptr[j];
+      if (coll->compatible(subset)) {
+        // if the current source is compatible, collect
+        coll->collect(indices, subset);
+      } else if (coll->can_promote(subset)) {
+        // setup a new Collecter
+        Collecter* new_collecter = promote_collecter(subset, gdf.nrows(), coll);
+
+        // import data from previous collecter.
+        new_collecter->collect(NaturalSlicingIndex(gdf.nrows()), coll->get());
+
+        // import data from this chunk
+        new_collecter->collect(indices, subset);
+
+        // dispose the previous collecter and keep the new one.
+        delete coll;
+        coll = new_collecter;
+      } else if (coll->is_logical_all_na()) {
+        Collecter* new_collecter = collecter(subset, gdf.nrows());
+        new_collecter->collect(indices, subset);
+        delete coll;
+        coll = new_collecter;
+      } else {
+        stop(
+          "Can not automatically convert from %s to %s in column \"%s\".",
+          coll->describe(), get_single_class(subset), name.get_cstring()
+        );
       }
     }
 
-    void check_type(SEXP subset) {
-      if (TYPEOF(subset) != RTYPE) {
-        stop("incompatible types, expecting a %s vector", vector_class<RTYPE>());
-      }
-    }
-
-    void grab_rep(STORAGE value, const SlicingIndex& indices) {
+    void grab_rep(SEXP value, const SlicingIndex& indices) {
       int n = indices.size();
+      // FIXME: This can be made faster if `source` in `Collecter->collect(source, indices)`
+      //        could be of length 1 recycling the value.
+      // TODO: create Collecter->collect_one(source, indices)?
       for (int j=0; j<n; j++) {
-        data[ indices[j] ] = value;
+        grab_along(value, RowwiseSlicingIndex(indices[j]));
       }
     }
 
     const Data& gdf;
     Proxy& proxy;
-    Vector<RTYPE> data;
+    Collecter *coll;
     int first_non_na;
+    const SymbolString& name;
 
   };
 
@@ -177,84 +201,6 @@ namespace dplyr {
 
   };
 
-  template <typename Data, typename Subsets>
-  class FactorGatherer : public Gatherer {
-  public:
-    typedef GroupedCallProxy<Data,Subsets> Proxy;
-    typedef IntegerVector Factor;
-
-    FactorGatherer(RObject& first, SlicingIndex& indices, Proxy& proxy_, const Data& gdf_, int first_non_na_) :
-      levels(), data(gdf_.nrows(), NA_INTEGER), first_non_na(first_non_na_), proxy(proxy_), gdf(gdf_)
-    {
-      if (first_non_na <  gdf.ngroups())
-        grab((SEXP)first, indices);
-      copy_most_attributes(data, first);
-    }
-
-    inline SEXP collect() {
-      int ngroups = gdf.ngroups();
-      typename Data::group_iterator git = gdf.group_begin();
-      int i = 0;
-      for (; i<first_non_na; i++) ++git;
-      for (; i<ngroups; i++, ++git) {
-        const SlicingIndex& indices = *git;
-        Factor subset(proxy.get(indices));
-        grab(subset, indices);
-      }
-      CharacterVector levels_(levels_vector.begin(), levels_vector.end());
-      set_levels(data, levels_);
-      return data;
-    }
-
-  private:
-    dplyr_hash_map<SEXP, int> levels;
-    Factor data;
-    int first_non_na;
-    Proxy& proxy;
-    const Data& gdf;
-    std::vector<SEXP> levels_vector;
-
-    void grab(Factor f, const SlicingIndex& indices) {
-      // update levels if needed
-      CharacterVector lev = get_levels(f);
-      std::vector<int> matches(lev.size());
-      int nlevels = levels.size();
-      for (int i=0; i<lev.size(); i++) {
-        SEXP level = lev[i];
-        if (!levels.count(level)) {
-          nlevels++;
-          levels_vector.push_back(level);
-          levels[level] = nlevels;
-          matches[i] = nlevels;
-        } else {
-          matches[i] = levels[level];
-        }
-      }
-
-      // grab data
-      int n = indices.size();
-
-      int nf = f.size();
-      if (n == nf) {
-        for (int i=0; i<n; i++) {
-          if (f[i] != NA_INTEGER) {
-            data[ indices[i] ] = matches[ f[i] - 1 ];
-          }
-        }
-      } else if (nf == 1) {
-        int value = NA_INTEGER;
-        if (f[0] != NA_INTEGER) {
-          value = matches[ f[0] - 1];
-          for (int i=0; i<n; i++) {
-            data[ indices[i] ] = value;
-          }
-        }
-      } else {
-        check_length(nf, n, "the group size");
-      }
-    }
-
-  };
 
   template <int RTYPE>
   class ConstantGathererImpl : public Gatherer {
@@ -321,31 +267,16 @@ namespace dplyr {
       first = proxy.get(indices);
     }
 
-    switch (TYPEOF(first)) {
-    case INTSXP:
-    {
-      if (Rf_inherits(first, "factor"))
-        return new FactorGatherer<Data, Subsets>(first, indices, proxy, gdf, i);
-      return new GathererImpl<INTSXP,Data,Subsets> (first, indices, proxy, gdf, i);
-    }
-    case REALSXP:
-      return new GathererImpl<REALSXP,Data,Subsets> (first, indices, proxy, gdf, i);
-    case LGLSXP:
-      return new GathererImpl<LGLSXP,Data,Subsets> (first, indices, proxy, gdf, i);
-    case STRSXP:
-      return new GathererImpl<STRSXP,Data,Subsets> (first, indices, proxy, gdf, i);
-    case VECSXP:
-      return new ListGatherer<Data,Subsets> (List(first), indices, proxy, gdf, i);
-    case CPLXSXP:
-      return new GathererImpl<CPLXSXP,Data,Subsets> (first, indices, proxy, gdf, i);
-    default:
-      break;
-    }
 
-    return 0;
+    if (TYPEOF(first) == VECSXP) {
+      return new ListGatherer<Data,Subsets> (List(first), indices, proxy, gdf, i);
+    } else {
+      return new GathererImpl<Data,Subsets> (first, indices, proxy, gdf, i, name);
+    }
   }
 
 } // namespace dplyr
 
 
 #endif
+

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -464,3 +464,10 @@ test_that("bind_rows accepts difftime objects", {
   res <- bind_rows(df1, df2)
   expect_equal(res$x, as.difftime(c(3600, 60), units = "secs"))
 })
+
+test_that("bind_rows accepts hms objects", {
+  df1 <- data.frame(x = hms::hms(hours = 1))
+  df2 <- data.frame(x = as.difftime(1, units = "mins"))
+  res <- bind_rows(df1, df2)
+  expect_equal(res$x, hms::hms(hours = c(1, 0), minutes = c(0, 1)))
+})

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -457,3 +457,11 @@ test_that("bind_rows rejects data frame columns (#2015)", {
     fixed = TRUE
   )
 })
+
+test_that("bind_rows accepts difftime objects", {
+  df1 <- data.frame(x = as.difftime(1, units = "hours"))
+  df2 <- data.frame(x = as.difftime(1, units = "mins"))
+  res <- bind_rows(df1, df2)
+  expect_equal(res$x,
+               c(df1$x, df2$x))
+})

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -462,6 +462,5 @@ test_that("bind_rows accepts difftime objects", {
   df1 <- data.frame(x = as.difftime(1, units = "hours"))
   df2 <- data.frame(x = as.difftime(1, units = "mins"))
   res <- bind_rows(df1, df2)
-  expect_equal(res$x,
-               c(df1$x, df2$x))
+  expect_equal(res$x, as.difftime(c(3600, 60), units = "secs"))
 })

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -191,5 +191,17 @@ test_that("combine works with difftime", {
 
 })
 
+test_that("combine works with hms and difftime", {
+  expect_equal(
+    combine(as.difftime(2, units = "weeks"), hms::hms(hours = 1)),
+    as.difftime(c(2*7*24*60*60, 3600), units = "secs")
+  )
+  expect_equal(
+    combine(hms::hms(hours = 1), as.difftime(2, units = "weeks")),
+    hms::hms(seconds = c(3600, 2*7*24*60*60))
+  )
+
+})
+
 # Uses helper-combine.R
 combine_coercion_types()

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -167,5 +167,29 @@ test_that("combine works with integer64 (#1092)", {
   )
 })
 
+test_that("combine works with difftime", {
+  expect_equal(
+    combine(as.difftime(1, units = "mins"), as.difftime(1, units = "hours")),
+    as.difftime(c(60, 3600), units = "secs")
+  )
+  expect_equal(
+    combine(as.difftime(1, units = "secs"), as.difftime(1, units = "secs")),
+    as.difftime(c(1, 1), units = "secs")
+  )
+  expect_equal(
+    combine(as.difftime(1, units = "days"), as.difftime(1, units = "secs")),
+    as.difftime(c(24*60*60, 1), units = "secs")
+  )
+  expect_equal(
+    combine(as.difftime(2, units = "weeks"), as.difftime(1, units = "secs")),
+    as.difftime(c(2*7*24*60*60, 1), units = "secs")
+  )
+  expect_equal(
+    combine(as.difftime(2, units = "weeks"), as.difftime(3, units = "weeks")),
+    as.difftime(c(2,3), units = "weeks")
+  )
+
+})
+
 # Uses helper-combine.R
 combine_coercion_types()

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -487,7 +487,7 @@ test_that("mutate handles factors (#1414)", {
     g = c(1, 1, 1, 2, 2, 3, 3),
     f = c("a", "b", "a", "a", "a", "b", "b")
   )
-  res <- d %>% group_by(g) %>% mutate(f2 = factor(f))
+  res <- d %>% group_by(g) %>% mutate(f2 = factor(f, levels = c("a", "b")))
   expect_equal(as.character(res$f2), res$f)
 })
 
@@ -575,7 +575,6 @@ test_that("grouped mutate does not drop grouping attributes (#1020)", {
 })
 
 test_that("grouped mutate coerces integer + double -> double (#1892)", {
-  skip("Currently failing")
   df <- data_frame(
     id = c(1, 4),
     value = c(1L, NA),
@@ -584,23 +583,29 @@ test_that("grouped mutate coerces integer + double -> double (#1892)", {
     group_by(group) %>%
     mutate(value = ifelse(is.na(value), 0, value))
   expect_type(df$value, "double")
-  expect_identical(df$value, c(0, 1))
+  expect_identical(df$value, c(1, 0))
 })
 
 test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)", {
-  skip("Currently failing")
+  factor_or_character <- function(x)  {
+    if (x > 3) {
+      return(factor("hello"))
+    } else {
+      return("world")
+    }
+  }
+
   df <- data_frame(
     id = c(1, 4),
-    value = factor(c("blue", NA)),
     group = c("A", "B")
   ) %>%
     group_by(group)
   expect_warning(
     df <- df %>%
-      mutate(value = ifelse(id > 3, "foo", value))
+      mutate(value = factor_or_character(id))
   )
   expect_type(df$value, "character")
-  expect_identical(df$value, c("blue", "foo"))
+  expect_identical(df$value, c("world", "hello"))
 })
 
 test_that("lead/lag works on more complex expressions (#1588)", {


### PR DESCRIPTION
This PR is a continuation to #2486 and closes #1892.

`mutate(col2 = fun(col1))` on a grouped data frame calls `fun` once per group.

It used to require that `fun` returns the exact same type on each call. That is not desirable in functions that may return different (but compatible) types, such as integer and numeric.

This PR changes that behavior, so the returned vectors from each of the `fun` calls are combined using the same coercion rules than `combine` and `bind_rows`, defined in `Collecter.h`.

Comments are welcome. Feel free to be picky, so I can improve a bit my C++ and Rcpp skills. :smiley: 