### PR TITLE
Add translation for log in postgres (#2464)

### DIFF
--- a/R/db-postgres.r
+++ b/R/db-postgres.r
@@ -10,17 +10,6 @@ src_desc.PostgreSQLConnection <- function(x) {
 #' @export
 sql_translate_env.PostgreSQLConnection <- function(con) {
   sql_variant(
-    base_scalar,
-    sql_translator(.parent = base_agg,
-      n = function() sql("count(*)"),
-      cor = sql_prefix("corr"),
-      cov = sql_prefix("covar_samp"),
-      sd =  sql_prefix("stddev_samp"),
-      var = sql_prefix("var_samp"),
-      all = sql_prefix("bool_and"),
-      any = sql_prefix("bool_or"),
-      paste = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
-    ),
     sql_translator(.parent = base_scalar,
       log = function(x, base = exp(1)) {
         if (isTRUE(all.equal(base, exp(1)))) {
@@ -31,6 +20,16 @@ sql_translate_env.PostgreSQLConnection <- function(con) {
           build_sql("log(", x, ") / log(", base, ")")
         }
       }
+    ),
+    sql_translator(.parent = base_agg,
+      n = function() sql("count(*)"),
+      cor = sql_prefix("corr"),
+      cov = sql_prefix("covar_samp"),
+      sd =  sql_prefix("stddev_samp"),
+      var = sql_prefix("var_samp"),
+      all = sql_prefix("bool_and"),
+      any = sql_prefix("bool_or"),
+      paste = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
     ),
     base_win
   )

--- a/R/db-postgres.r
+++ b/R/db-postgres.r
@@ -21,6 +21,17 @@ sql_translate_env.PostgreSQLConnection <- function(con) {
       any = sql_prefix("bool_or"),
       paste = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
     ),
+    sql_translator(.parent = base_scalar,
+      log = function(x, base = exp(1)) {
+        if (isTRUE(all.equal(base, exp(1)))) {
+          build_sql("ln(", x, ")")
+        } else {
+          # Use log change-of-base because postgres doesn't support the
+          # two-argument "log(base, x)" for floating point x.
+          build_sql("log(", x, ") / log(", base, ")")
+        }
+      }
+    ),
     base_win
   )
 }

--- a/R/translate-sql-base.r
+++ b/R/translate-sql-base.r
@@ -75,7 +75,11 @@ base_scalar <- sql_translator(
   exp     = sql_prefix("exp", 1),
   floor   = sql_prefix("floor", 1),
   log     = function(x, base = exp(1)) {
-    build_sql(sql("log"), list(base, x))
+    if (isTRUE(all.equal(base, exp(1)))) {
+      build_sql(sql("ln"), list(x))
+    } else {
+      build_sql(sql("log"), list(base, x))
+    }
   },
   log10   = sql_prefix("log10", 1),
   round   = sql_prefix("round", 2),

--- a/tests/testthat/test-sql-translation.r
+++ b/tests/testthat/test-sql-translation.r
@@ -151,6 +151,11 @@ test_that("log base comes first", {
   expect_equal(translate_sql(log(x, 10)), sql('log(10.0, "x")'))
 })
 
+test_that("log becomes ln", {
+  expect_equal(translate_sql(log(x)), sql('ln("x")'))
+  expect_equal(translate_sql(log(x, exp(1))), sql('ln("x")'))
+})
+
 test_that("sqlite mimics two argument log", {
   translate_sqlite <- function(...) {
     translate_sql(..., con = src_memdb()$con)
@@ -158,6 +163,16 @@ test_that("sqlite mimics two argument log", {
 
   expect_equal(translate_sqlite(log(x)), sql('log(`x`)'))
   expect_equal(translate_sqlite(log(x, 10)), sql('log(`x`) / log(10.0)'))
+})
+
+test_that("postgres mimics two argument log", {
+  translate_postgres <- function(...) {
+    translate_sql(..., con = src_postgres()$con)
+  }
+
+  expect_equal(translate_postgres(log(x)), sql('ln("x")'))
+  expect_equal(translate_postgres(log(x, 10)), sql('log("x") / log(10.0)'))
+  expect_equal(translate_postgres(log(x, 10L)), sql('log("x") / log(10)'))
 })
 
 # partial_eval() ----------------------------------------------------------

--- a/tests/testthat/test-sql-translation.r
+++ b/tests/testthat/test-sql-translation.r
@@ -153,7 +153,6 @@ test_that("log base comes first", {
 
 test_that("log becomes ln", {
   expect_equal(translate_sql(log(x)), sql('ln("x")'))
-  expect_equal(translate_sql(log(x, exp(1))), sql('ln("x")'))
 })
 
 test_that("sqlite mimics two argument log", {

--- a/tests/testthat/test-sql-translation.r
+++ b/tests/testthat/test-sql-translation.r
@@ -166,7 +166,10 @@ test_that("sqlite mimics two argument log", {
 
 test_that("postgres mimics two argument log", {
   translate_postgres <- function(...) {
-    translate_sql(..., con = src_postgres()$con)
+    # Slightly hacky, but fake the postgres connection rather than hassling
+    # with a system- or CI-dependent call to src_postgres().
+    con <- structure(list(), class = "PostgreSQLConnection")
+    translate_sql(..., con = con)
   }
 
   expect_equal(translate_postgres(log(x)), sql('ln("x")'))


### PR DESCRIPTION
This gets around the issue that postgres doesn't support two-argument
`log(base, x)` for floating point `x`.

- For default SQL: if log base is *e*, use `ln()`.
- For postgres: if log base is *e*, use `ln()`.
- For postgres: if log base isn't *e*, use `log(x) / log(base)`.
- Add tests.