### PR TITLE
Fix hybrid handler for first(), last(), and nth()

### DIFF
--- a/inst/include/dplyr/Result/VectorSliceVisitor.h
+++ b/inst/include/dplyr/Result/VectorSliceVisitor.h
@@ -10,15 +10,14 @@ namespace dplyr {
   public:
     typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
 
-    VectorSliceVisitor(SEXP data_, const SlicingIndex& index_) :
+    VectorSliceVisitor(const Vector<RTYPE>& data_, const SlicingIndex& index_) :
       data(data_),
-      ptr(Rcpp::internal::r_vector_start<RTYPE>(data)),
       n(index_.size()),
       index(index_)
     {}
 
     inline STORAGE operator[](int i) const {
-      return ptr[index[i]];
+      return data[index[i]];
     }
 
     inline int size() const {
@@ -30,8 +29,7 @@ namespace dplyr {
     }
 
   private:
-    SEXP data;
-    STORAGE* ptr;
+    const Vector<RTYPE>& data;
     int n;
     const SlicingIndex& index;
   };

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -95,6 +95,8 @@ Result* nth_with(Vector<RTYPE> data, int idx, SEXP order) {
     return new NthWith<RTYPE, INTSXP>(data, idx, order);
   case REALSXP:
     return new NthWith<RTYPE, REALSXP>(data, idx, order);
+  case CPLXSXP:
+    return new NthWith<RTYPE, CPLXSXP>(data, idx, order);
   case STRSXP:
     return new NthWith<RTYPE, STRSXP>(data, idx, order);
   default:
@@ -113,6 +115,8 @@ Result* nth_with_default(Vector<RTYPE> data, int idx, SEXP order, Vector<RTYPE> 
     return new NthWith<RTYPE, INTSXP>(data, idx, order, def[0]);
   case REALSXP:
     return new NthWith<RTYPE, REALSXP>(data, idx, order, def[0]);
+  case CPLXSXP:
+    return new NthWith<RTYPE, CPLXSXP>(data, idx, order, def[0]);
   case STRSXP:
     return new NthWith<RTYPE, STRSXP>(data, idx, order, def[0]);
   default:

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -185,17 +185,19 @@ namespace dplyr {
     // now get `order_by` and default
     SEXP order_by = R_NilValue;
     SEXP def    = R_NilValue;
+    bool has_order_by = false;
+    bool has_default = false;
 
     SEXP p = CDR(CDDR(call));
     while (p != R_NilValue) {
       SEXP tag = TAG(p);
-      if (tag == R_NilValue) return 0;
-      std::string argname = CHAR(PRINTNAME(tag));
-      if (argmatch("order_by", argname)) {
+      if (!has_order_by && (Rf_isNull(tag) || argmatch("order_by", CHAR(PRINTNAME(tag))))) {
         order_by = CAR(p);
+        has_order_by = true;
       }
-      else if (argmatch("default", argname)) {
+      else if (!has_default && (Rf_isNull(tag) || argmatch("default", CHAR(PRINTNAME(tag))))) {
         def = CAR(p);
+        has_default = true;
       }
       else {
         return 0;

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -59,14 +59,19 @@ namespace dplyr {
       int n = indices.size();
       if (n == 0 || idx > n || idx < -n) return def;
 
-      int i = idx > 0 ? (idx -1) : (n+idx);
+      int i = idx > 0 ? (idx - 1) : (n + idx);
 
       typedef VectorSliceVisitor<ORDER_RTYPE> Slice;
       typedef OrderVectorVisitorImpl<ORDER_RTYPE,true,Slice> Visitor;
       typedef Compare_Single_OrderVisitor<Visitor> Comparer;
 
-      Comparer comparer(Visitor(Slice(order, indices)));
-      IntegerVector sequence = seq(0,n-1);
+      // Need explicit variables because constructors take const&, and this does not work
+      // with unnamed temporaries.
+      Slice slice(order, indices);
+      Visitor visitor(slice);
+      Comparer comparer(visitor);
+
+      IntegerVector sequence = seq(0, n - 1);
       std::nth_element(sequence.begin(), sequence.begin() + i, sequence.end(), comparer);
 
       return data[ indices[ sequence[i] ] ];

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -328,27 +328,15 @@ test_that("first(), last(), and nth() work", {
     expected = "d"
   )
 
-  skip("Currently failing (data types)")
   check_hybrid_result(
     nth(a, 3), a = as.numeric(1:5) * 1i,
     expected = 3i
-  )
-  check_hybrid_result(
-    nth(a, 1 + 2), a = letters[1:5],
-    expected = "c"
   )
   check_not_hybrid_result(
     nth(a, 2), a = as.list(1:5),
     expected = 2L
   )
 
-  skip("Currently failing (negative value)")
-  check_hybrid_result(
-    nth(a, -4), a = 1:5,
-    expected = 2L
-  )
-
-  skip("Currently failing (match call)")
   check_not_hybrid_result(
     nth(a, order_by = 5:1, 2), a = 1:5,
     expected = 4L
@@ -366,7 +354,6 @@ test_that("first(), last(), and nth() work", {
     error = "unused argument"
   )
 
-  skip("Currently failing (external variable)")
   c <- 1:3
   check_not_hybrid_result(
     first(c), a = 2:4,
@@ -381,10 +368,20 @@ test_that("first(), last(), and nth() work", {
     expected = 2L
   )
 
-  skip("Currently failing (segfault)")
-  check_not_hybrid_result(
+  check_hybrid_result(
     first(a, order_by = b), a = 1:5, b = 5:1,
     expected = 5L
+  )
+
+  skip("Currently failing (constfold)")
+  check_hybrid_result(
+    nth(a, 1 + 2), a = letters[1:5],
+    expected = "c"
+  )
+
+  check_hybrid_result(
+    nth(a, -4), a = 1:5,
+    expected = 2L
   )
 })
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -283,7 +283,11 @@ test_that("hybrid evaluation goes deep enough (#554)", {
 })
 
 test_that("hybrid does not segfault when given non existing variable (#569)", {
-  expect_error(mtcars %>% summarise(first(mp)), "could not find variable")
+  expect_error(
+    mtcars %>% summarise(first(mp)),
+    "object 'mp' not found",
+    fixed = TRUE
+  )
 })
 
 test_that("namespace extraction works in hybrid (#412)", {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -425,6 +425,13 @@ test_that("LazyGroupSubsets is robust about columns not from the data (#600)", {
   )
 })
 
+test_that("can summsarise first(x[-1]) (#1980)", {
+  expect_equal(
+    tibble(x = 1:3) %>% summarise(f = first(x[-1])),
+    tibble(f = 2L)
+  )
+})
+
 test_that("hybrid eval handles $ and @ (#645)", {
   tmp <- expand.grid(a = 1:3, b = 0:1, i = 1:10)
   g   <- tmp %>% group_by(a)

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -426,7 +426,7 @@ test_that("LazyGroupSubsets is robust about columns not from the data (#600)", {
   )
 })
 
-test_that("can summsarise first(x[-1]) (#1980)", {
+test_that("can summarise first(x[-1]) (#1980)", {
   expect_equal(
     tibble(x = 1:3) %>% summarise(f = first(x[-1])),
     tibble(f = 2L)

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -421,7 +421,8 @@ test_that("LazyGroupSubsets is robust about columns not from the data (#600)", {
   foo <- data_frame(x = 1:10, y = 1:10)
   expect_error(
     foo %>% group_by(x) %>% summarise(first_y = first(z)),
-    "could not find variable"
+    "object 'z' not found",
+    fixed = TRUE
   )
 })
 


### PR DESCRIPTION
- avoid segfault when using `order_by`
- support complex
- fall back to standard if `n` is a `LANGSXP`

Fixes #1980.