### PR TITLE
Clean up hybrid handler for lead() and lag()

### DIFF
--- a/src/hybrid_offset.cpp
+++ b/src/hybrid_offset.cpp
@@ -12,39 +12,42 @@ using namespace dplyr;
 
 struct LeadLag {
 
-  LeadLag(SEXP call) : data(R_NilValue), n(1), def(R_NilValue), ok(true) {
+  LeadLag(SEXP call) : data(R_NilValue), n(1), def(R_NilValue), ok(false) {
 
     SEXP p = CDR(call);
     SEXP tag = TAG(p);
-    if (tag != R_NilValue && tag != Rf_install("x")) {
-      ok = false;
+    if (tag != R_NilValue && tag != Rf_install("x"))
       return;
-    }
     data = CAR(p);
-
     p = CDR(p);
-    while (p != R_NilValue) {
+
+    SEXP tag_default = Rf_install("default");
+    SEXP tag_n = Rf_install("n");
+    bool got_n = false;
+    bool got_default = false;
+
+    while (!Rf_isNull(p)) {
       tag = TAG(p);
-      if (tag != R_NilValue && tag != Rf_install("n") && tag != Rf_install("default")) {
-        ok = false;
+      if (!Rf_isNull(tag) && tag != tag_n && tag != tag_default)
         return;
+      if (!got_n && (Rf_isNull(tag) || tag == tag_n)) {
+        SEXP n_ = CAR(p);
+        if (TYPEOF(n_) != INTSXP && TYPEOF(n_) != REALSXP)
+          return;
+        n = as<int>(n_);
+        got_n = true;
       }
-      if (tag == Rf_install("n") || tag == R_NilValue) {
-        try {
-          n = as<int>(CAR(p));
-        } catch (...) {
-          SEXP n_ = CADDR(call);
-          std::stringstream s;
-          stop("could not convert second argument to an integer. type=%s, length = %d",
-               type2name(n_), Rf_length(n_));
-        }
-      }
-      if (tag == Rf_install("default")) {
+      else if (!got_default && (Rf_isNull(tag) || tag == tag_default)) {
+        if (TYPEOF(def) == LANGSXP) return;
         def = CAR(p);
-        if (TYPEOF(def) == LANGSXP) ok = false;
+        got_default = true;
       }
+      else
+        return;
       p = CDR(p);
     }
+
+    ok = true;
   }
 
   RObject data;
@@ -65,25 +68,27 @@ Result* leadlag_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     return 0;
 
   SymbolString name = SymbolString(Symbol(data));
-  if (subsets.count(name)) {
-    bool is_summary = subsets.is_summary(name);
-    int n = args.n;
-    data = subsets.get_variable(name);
+  if (subsets.count(name) == 0)
+    return 0;
 
-    switch (TYPEOF(data)) {
-    case INTSXP:
-      return new Templ<INTSXP>(data, n, args.def, is_summary);
-    case REALSXP:
-      return new Templ<REALSXP>(data, n, args.def, is_summary);
-    case STRSXP:
-      return new Templ<STRSXP>(data, n, args.def, is_summary);
-    case LGLSXP:
-      return new Templ<LGLSXP>(data, n, args.def, is_summary);
-    default:
-      break;
-    }
+  bool is_summary = subsets.is_summary(name);
+  int n = args.n;
+  data = subsets.get_variable(name);
+
+  switch (TYPEOF(data)) {
+  case INTSXP:
+    return new Templ<INTSXP>(data, n, args.def, is_summary);
+  case REALSXP:
+    return new Templ<REALSXP>(data, n, args.def, is_summary);
+  case CPLXSXP:
+    return new Templ<CPLXSXP>(data, n, args.def, is_summary);
+  case STRSXP:
+    return new Templ<STRSXP>(data, n, args.def, is_summary);
+  case LGLSXP:
+    return new Templ<LGLSXP>(data, n, args.def, is_summary);
+  default:
+    return 0;
   }
-  return 0;
 }
 
 void install_offset_handlers(HybridHandlerMap& handlers) {

--- a/src/hybrid_offset.cpp
+++ b/src/hybrid_offset.cpp
@@ -38,8 +38,8 @@ struct LeadLag {
         got_n = true;
       }
       else if (!got_default && (Rf_isNull(tag) || tag == tag_default)) {
-        if (TYPEOF(def) == LANGSXP) return;
         def = CAR(p);
+        if (TYPEOF(def) == LANGSXP) return;
         got_default = true;
       }
       else

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -426,15 +426,6 @@ test_that("lead() and lag() work", {
   )
 
   check_not_hybrid_result(
-    list(lead(a, default = 2 + 4)), a = 1:5,
-    expected = list(as.numeric(2:6))
-  )
-  check_not_hybrid_result(
-    list(lag(a, default = 3L - 3L)), a = as.numeric(1:5),
-    expected = list(as.numeric(0:4))
-  )
-
-  check_not_hybrid_result(
     list(lead(a, order_by = b)), a = 1:5, b = 5:1,
     expected = list(c(NA, 1:4))
   )
@@ -443,7 +434,6 @@ test_that("lead() and lag() work", {
     expected = list(c(2:5, NA))
   )
 
-  skip("Currently failing (complex)")
   check_hybrid_result(
     list(lead(a)), a = 1:5 * 1i,
     expected = list(c(2:5, NA) * 1i)
@@ -453,7 +443,17 @@ test_that("lead() and lag() work", {
     expected = list(c(NA, 1:4) * 1i)
   )
 
-  skip("Currently failing")
+  v <- 1:2
+  check_not_hybrid_result(
+    list(lead(a, v[1])), a = 1:5,
+    expected = list(c(2:5, NA))
+  )
+  check_not_hybrid_result(
+    list(lag(a, v[1])), a = 1:5,
+    expected = list(c(NA, 1:4))
+  )
+
+  skip("Currently failing (constfold)")
   check_hybrid_result(
     list(lead(a, 1L + 2L)), a = 1:5,
     expected = list(c(4:5, NA, NA, NA))
@@ -461,6 +461,15 @@ test_that("lead() and lag() work", {
   check_hybrid_result(
     list(lag(a, 4L - 2L)), a = as.numeric(1:5),
     expected = list(c(NA, NA, as.numeric(1:3)))
+  )
+
+  check_not_hybrid_result(
+    list(lead(a, default = 2 + 4)), a = 1:5,
+    expected = list(as.numeric(2:6))
+  )
+  check_not_hybrid_result(
+    list(lag(a, default = 3L - 3L)), a = as.numeric(1:5),
+    expected = list(as.numeric(0:4))
   )
 
   check_hybrid_result(


### PR DESCRIPTION
- Better argument matching
- Fall back to standard evaluation if `n` is a `LANGSXP`

Fixes #946.