### PR TITLE
Change 'sql_translate' to 'translate_sql' in doc

### DIFF
--- a/R/translate-sql.r
+++ b/R/translate-sql.r
@@ -25,8 +25,8 @@
 #' The SQLite variant currently only adds one additional function: a mapping
 #' from `sd()` to the SQL aggregation function `STDEV`.
 #'
-#' @param ...,dots Expressions to translate. `sql_translate()`
-#'   automatically quotes them for you.  `sql_translate_()` expects
+#' @param ...,dots Expressions to translate. `translate_sql()`
+#'   automatically quotes them for you.  `translate_sql_()` expects
 #'   a list of already quoted objects.
 #' @param con An optional database connection to control the details of
 #'   the translation. The default, `NULL`, generates ANSI SQL.

--- a/man/translate_sql.Rd
+++ b/man/translate_sql.Rd
@@ -12,8 +12,8 @@ translate_sql_(dots, con = NULL, vars_group = NULL, vars_order = NULL,
   window = TRUE)
 }
 \arguments{
-\item{..., dots}{Expressions to translate. \code{sql_translate()}
-automatically quotes them for you.  \code{sql_translate_()} expects
+\item{..., dots}{Expressions to translate. \code{translate_sql()}
+automatically quotes them for you.  \code{translate_sql_()} expects
 a list of already quoted objects.}
 
 \item{con}{An optional database connection to control the details of


### PR DESCRIPTION
I believe these were in error or from older versions, and the documentation should read `translate_sql()` not `sql_translate()`. 