### PR TITLE
Add missing con = win_current_con()

### DIFF
--- a/R/translate-sql-window.r
+++ b/R/translate-sql-window.r
@@ -44,7 +44,11 @@ win_over <- function(expr, partition = NULL, order = NULL, frame = NULL) {
 
     order <- build_sql(
       "ORDER BY ",
-      sql_vector(escape(order), collapse = ", ", parens = FALSE)
+      sql_vector(
+        escape(order, con = win_current_con()),
+        collapse = ", ",
+        parens = FALSE
+      )
     )
   }
   if (!is.null(frame)) {


### PR DESCRIPTION
Queries with ORDER BY in OVER() failed with a SQL backend that uses non-standard identifier quoting because double quotes were inserted around identifiers.