### PR TITLE
Always strip names from result

### DIFF
--- a/inst/include/dplyr/NamedListAccumulator.h
+++ b/inst/include/dplyr/NamedListAccumulator.h
@@ -19,6 +19,8 @@ namespace dplyr {
       if (! Rcpp::traits::same_type<Data, RowwiseDataFrame>::value)
         check_supported_type(x, name);
 
+      Rf_setAttrib(x, R_NamesSymbol, R_NilValue);
+
       SymbolMapIndex index = symbol_map.insert(name);
       if (index.origin == NEW) {
         data.push_back(x);

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -230,6 +230,17 @@ test_that("mutate remove variables with = NULL syntax (#462)", {
   expect_false("cyl" %in% names(data))
 })
 
+test_that("mutate strips names (#1689)", {
+  data <- data_frame(a = 1:3) %>% mutate(b = setNames(nm = a))
+  expect_null(names(data$b))
+
+  data <- data_frame(a = 1:3) %>% rowwise %>% mutate(b = setNames(nm = a))
+  expect_null(names(data$b))
+
+  data <- data_frame(a = c(1, 1, 2)) %>% group_by(a) %>% mutate(b = setNames(nm = a))
+  expect_null(names(data$b))
+})
+
 test_that("mutate gives a nice error message if an expression evaluates to NULL (#2187)", {
   expect_error(
     data_frame(a = 1) %>% mutate(b = identity(NULL)),
@@ -479,7 +490,7 @@ test_that("mutate handles the all NA case (#958)", {
   expect_true(all(is.na(res$adjusted_values[1:12])))
 })
 
-test_that("rowwie mutate gives expected results (#1381)", {
+test_that("rowwise mutate gives expected results (#1381)", {
   f <- function(x) ifelse(x < 2, NA_real_, x)
   res <- data_frame(x = 1:3) %>% rowwise() %>% mutate(y = f(x))
   expect_equal(res$y, c(NA, 2, 3))
@@ -493,8 +504,6 @@ test_that("mutate handles factors (#1414)", {
   res <- d %>% group_by(g) %>% mutate(f2 = factor(f, levels = c("a", "b")))
   expect_equal(as.character(res$f2), res$f)
 })
-
-# .data and .env tests now in test-hybrid-traverse.R
 
 test_that("mutate handles results from one group with all NA values (#1463) ", {
   df <- data_frame(x = c(1, 2), y = c(1, NA))

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -189,6 +189,17 @@ test_that("summarise propagate attributes (#194)", {
 
 })
 
+test_that("summarise strips names (#2231)", {
+  data <- data_frame(a = 1:3) %>% summarise(b = setNames(nm = a[[1]]))
+  expect_null(names(data$b))
+
+  data <- data_frame(a = 1:3) %>% rowwise %>% mutate(b = setNames(nm = a))
+  expect_null(names(data$b))
+
+  data <- data_frame(a = c(1, 1, 2)) %>% group_by(a) %>% mutate(b = setNames(nm = a[[1]]))
+  expect_null(names(data$b))
+})
+
 test_that("summarise fails on missing variables", {
   expect_error(summarise(mtcars, a = mean(notthear)))
 })

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -193,10 +193,10 @@ test_that("summarise strips names (#2231)", {
   data <- data_frame(a = 1:3) %>% summarise(b = setNames(nm = a[[1]]))
   expect_null(names(data$b))
 
-  data <- data_frame(a = 1:3) %>% rowwise %>% mutate(b = setNames(nm = a))
+  data <- data_frame(a = 1:3) %>% rowwise %>% summarise(b = setNames(nm = a))
   expect_null(names(data$b))
 
-  data <- data_frame(a = c(1, 1, 2)) %>% group_by(a) %>% mutate(b = setNames(nm = a[[1]]))
+  data <- data_frame(a = c(1, 1, 2)) %>% group_by(a) %>% summarise(b = setNames(nm = a[[1]]))
   expect_null(names(data$b))
 })
 


### PR DESCRIPTION
in ungrouped `mutate()` and `summarise()`.

Fixes #1689.