### PR TITLE
Duplicate summary values of type list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ notifications:
 #before_script
 before_script:
 - psql -c 'create database test;' -U postgres
-- R -q -e 'install.packages("http://cran.r-project.org/src/contrib/Archive/Rcpp/Rcpp_0.12.7.tar.gz", repos = NULL)'
 
 #after_success
 after_success:

--- a/inst/include/dplyr/Result/DelayedProcessor.h
+++ b/inst/include/dplyr/Result/DelayedProcessor.h
@@ -233,7 +233,7 @@ namespace dplyr {
 
     virtual bool try_handle(const RObject& chunk) {
       if (is<List>(chunk) && Rf_length(chunk) == 1) {
-        res[pos++] = maybe_copy(VECTOR_ELT(chunk, 0));
+        res[pos++] = Rf_duplicate(VECTOR_ELT(chunk, 0));
         return true;
       }
       return false;
@@ -254,10 +254,6 @@ namespace dplyr {
   private:
     List res;
     int pos;
-
-    inline SEXP maybe_copy(SEXP x) const {
-      return is_ShrinkableVector(x) ? Rf_duplicate(x) : x;
-    }
   };
 
   template <typename CLASS>

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -898,3 +898,11 @@ test_that("ungrouped summarise() uses summary variables correctly (#2404)", {
   expect_equal(out$value, 5.5)
   expect_equal(out$sd, NA_real_)
 })
+
+test_that("proper handling of names in summarised list columns (#2231)", {
+  d <- data_frame(x = rep(1:3, 1:3), y = 1:6, names = letters[1:6])
+  res <- d %>% group_by(x) %>% summarise(y = list(setNames(y, names)))
+  expect_equal(names(res$y[[1]]), letters[[1]])
+  expect_equal(names(res$y[[2]]), letters[2:3])
+  expect_equal(names(res$y[[3]]), letters[4:6])
+})


### PR DESCRIPTION
to copy all attributes.

Fixes #2231.