### PR TITLE
Fix very rare case of false match during join

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.5.0.9000
 
+* Fixed very rare case of false match during join (#2515).
+
 * Restricted workaround for `match()` to R 3.3.0. (#1858).
 
 * dplyr now warns on load when the version of R or Rcpp during installation is

--- a/inst/include/dplyr/JoinVisitorImpl.h
+++ b/inst/include/dplyr/JoinVisitorImpl.h
@@ -36,7 +36,7 @@ namespace dplyr {
       if (i>=0 && j>=0) {
         return comparisons<LHS_RTYPE>().equal_or_both_na(left[i], left[j]);
       } else if (i < 0 && j < 0) {
-        return comparisons<LHS_RTYPE>().equal_or_both_na(right[-i-1], right[-j-1]);
+        return comparisons<RHS_RTYPE>().equal_or_both_na(right[-i-1], right[-j-1]);
       } else if (i >= 0 && j < 0) {
         return comparisons_different<LHS_RTYPE,RHS_RTYPE>().equal_or_both_na(left[i], right[-j-1]);
       } else {


### PR DESCRIPTION
Under the following conditions, a false match during a join could have occurred theoretically:

- Joining an integer and a numeric column
- Two numeric values have the same integer component but different fractional components, **and** hash to the same value

It is unlikely that this has been ever observed, but it might be possible to construct an artificial example.