### PR TITLE
Fix mutation of list-column names in mutate()

### DIFF
--- a/inst/include/dplyr/NamedListAccumulator.h
+++ b/inst/include/dplyr/NamedListAccumulator.h
@@ -19,7 +19,8 @@ namespace dplyr {
       if (! Rcpp::traits::same_type<Data, RowwiseDataFrame>::value)
         check_supported_type(x, name);
 
-      Rf_setAttrib(x, R_NamesSymbol, R_NilValue);
+      if (TYPEOF(x) != VECSXP)
+        Rf_setAttrib(x, R_NamesSymbol, R_NilValue);
 
       SymbolMapIndex index = symbol_map.insert(name);
       if (index.origin == NEW) {

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -241,6 +241,14 @@ test_that("mutate strips names (#1689)", {
   expect_null(names(data$b))
 })
 
+test_that("mutate doesn't strip names of list-columns", {
+  vec <- list(a = 1, b = 2)
+  data <- data_frame(x = vec)
+  data <- mutate(data, x)
+  expect_identical(names(vec), c("a", "b"))
+  expect_identical(names(data$x), c("a", "b"))
+})
+
 test_that("mutate gives a nice error message if an expression evaluates to NULL (#2187)", {
   expect_error(
     data_frame(a = 1) %>% mutate(b = identity(NULL)),


### PR DESCRIPTION
Fixes a bug introduced in #2512 

It would change the names of list-columns by reference:

```r
df <- data_frame(y = list(a = 1, b = 1:2))
names(df$y)
#> [1] "a" "b"

dplyr::mutate(df, y)
names(df$y)
#> NULL
```