### PR TITLE
Remove leading underscores from join tables

### DIFF
--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -111,15 +111,15 @@ sql_join.default <- function(con, x, y, vars, type = "inner", by = NULL, ...) {
   )
 
   select <- sql_vector(c(
-    sql_as(con, names(vars$x), vars$x, table = "_LEFT"),
-    sql_as(con, names(vars$y), vars$y, table = "_RIGHT")
+    sql_as(con, names(vars$x), vars$x, table = "TBL_LEFT"),
+    sql_as(con, names(vars$y), vars$y, table = "TBL_RIGHT")
   ), collapse = ", ", parens = FALSE)
 
   on <- sql_vector(
     paste0(
-      sql_table_prefix(con, by$x, "_LEFT"),
+      sql_table_prefix(con, by$x, "TBL_LEFT"),
       " = ",
-      sql_table_prefix(con, by$y, "_RIGHT")
+      sql_table_prefix(con, by$y, "TBL_RIGHT")
     ),
     collapse = " AND ",
     parens = TRUE
@@ -172,9 +172,9 @@ sql_semi_join <- function(con, x, y, anti = FALSE, by = NULL, ...) {
 }
 #' @export
 sql_semi_join.default <- function(con, x, y, anti = FALSE, by = NULL, ...) {
-  # X and Y are subqueries named _LEFT and _RIGHT
-  left <- escape(ident("_LEFT"), con = con)
-  right <- escape(ident("_RIGHT"), con = con)
+  # X and Y are subqueries named TBL_LEFT and TBL_RIGHT
+  left <- escape(ident("TBL_LEFT"), con = con)
+  right <- escape(ident("TBL_RIGHT"), con = con)
   on <- sql_vector(
     paste0(
       left,  ".", sql_escape_ident(con, by$x), " = ",

--- a/R/sql-render.R
+++ b/R/sql-render.R
@@ -53,16 +53,16 @@ sql_render.sql <- function(query, con = NULL, ...) {
 
 #' @export
 sql_render.join_query <- function(query, con = NULL, ..., root = FALSE) {
-  from_x <- sql_subquery(con, sql_render(query$x, con, ..., root = root), name = "_LEFT")
-  from_y <- sql_subquery(con, sql_render(query$y, con, ..., root = root), name = "_RIGHT")
+  from_x <- sql_subquery(con, sql_render(query$x, con, ..., root = root), name = "TBL_LEFT")
+  from_y <- sql_subquery(con, sql_render(query$y, con, ..., root = root), name = "TBL_RIGHT")
 
   sql_join(con, from_x, from_y, vars = query$vars, type = query$type, by = query$by)
 }
 
 #' @export
 sql_render.semi_join_query <- function(query, con = NULL, ..., root = FALSE) {
-  from_x <- sql_subquery(con, sql_render(query$x, con, ..., root = root), name = "_LEFT")
-  from_y <- sql_subquery(con, sql_render(query$y, con, ..., root = root), name = "_RIGHT")
+  from_x <- sql_subquery(con, sql_render(query$x, con, ..., root = root), name = "TBL_LEFT")
+  from_y <- sql_subquery(con, sql_render(query$y, con, ..., root = root), name = "TBL_RIGHT")
 
   sql_semi_join(con, from_x, from_y, anti = query$anti, by = query$by)
 }


### PR DESCRIPTION
This would fix #2526 by removing the leading underscore from tables in joins. Change made essentially via a Perl `s/_(LEFT|RIGHT)/TBL_$1/g;`. I have tested this with my `db2` package and it fixes my problems.