### PR TITLE
Make codecov quiet

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,12 @@
 comment: false
+
+coverage:
+  status:
+    patch:
+      default:
+        target: 0
+        threshold: 100
+    project:
+      default:
+        target: 70
+        threshold: 100


### PR DESCRIPTION
So a red mark means that the build is broken rather than the coverage has dropped.