### PR TITLE
Fix documentation for the `...` parameter in rename/select

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -299,8 +299,8 @@ arrange_ <- function(.data, ..., .dots = list()) {
 #'
 #' @inheritParams filter
 #' @inheritSection filter Tidy data
-#' @param ... Comma separated list of unquoted expressions. You can treat
-#'   variable names like they are positions.
+#' @param ... One or more unquoted expressions separated by commas.
+#'   You can treat variable names like they are positions.
 #'
 #'   Positive values select variables; negative values to drop variables.
 #'


### PR DESCRIPTION
## tl;dr

You can't pass a `list()` to `select()`/`rename()`. 

But, the documentation suggests you can. I rephrased the documentation to make it clear a `list()` won't work.

## Longer version

The documentation for the `...` parameter in `select()`/`rename()` parameters begins: 

```r
#' @param ... One or more unquoted expressions separated by commas.
```

But that docstring is incorrect: you can't use R's formal `list()` to pass in multiple unquoted expressions. As evidence, the following are some examples of statements that fail when trying to use `list()`

```r
rename(iris, list(petal_length = Petal.Length))
# Error: All arguments to `rename()` must be named.

rename(iris, list(Petal.Length = petal_length))
# Error: All arguments to `rename()` must be named.

select(iris, list(Petal.Length))
# Error: All select() inputs must resolve to integer column positions.
# The following do not:
# *  list(Petal.Length)

select(iris, list(Petal.Length, Petal.Width))
# Error: All select() inputs must resolve to integer column positions.
# The following do not:
#   *  list(Petal.Length, Petal.Width)
```