### PR TITLE
mutate() recycles list columns of length 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.5.0.9000
 
+* `mutate()` recycles list columns of length 1 (#2171).
+
 * Fixed very rare case of false match during join (#2515).
 
 * Restricted workaround for `match()` to R 3.3.0. (#1858).

--- a/inst/include/dplyr/Gatherer.h
+++ b/inst/include/dplyr/Gatherer.h
@@ -235,7 +235,7 @@ namespace dplyr {
     case CPLXSXP:
       return new ConstantGathererImpl<CPLXSXP>(x, n);
     case VECSXP:
-      return new ConstantGathererImpl<STRSXP>(x, n);
+      return new ConstantGathererImpl<VECSXP>(x, n);
     default:
       break;
     }

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -91,12 +91,14 @@ test_that("mutate recycles results of length 1", {
   str  <- "foo"
   num  <- 1
   bool <- TRUE
+  list <- list(NULL)
 
-  res <- mutate(group_by(df, x), int = int, str = str, num = num, bool = bool)
+  res <- mutate(group_by(df, x), int = int, str = str, num = num, bool = bool, list = list)
   expect_equal(res$int , rep(int , 4))
   expect_equal(res$str , rep(str , 4))
   expect_equal(res$num , rep(num , 4))
   expect_equal(res$bool, rep(bool, 4))
+  expect_equal(res$list, rep(list, 4))
 })
 
 


### PR DESCRIPTION
Fixes #2171.