### PR TITLE
Cleanup around subset()

### DIFF
--- a/inst/include/dplyr/DataFrameColumnSubsetVisitor.h
+++ b/inst/include/dplyr/DataFrameColumnSubsetVisitor.h
@@ -25,10 +25,6 @@ namespace dplyr {
       return visitors.subset(index, get_class(data));
     }
 
-    inline SEXP subset(const Rcpp::LogicalVector& index) const {
-      return visitors.subset(index, get_class(data));
-    }
-
     inline SEXP subset(EmptySubset index) const {
       return visitors.subset(index, get_class(data));
     }

--- a/inst/include/dplyr/DataFrameSubsetVisitors.h
+++ b/inst/include/dplyr/DataFrameSubsetVisitors.h
@@ -98,11 +98,11 @@ namespace dplyr {
   template <>
   inline DataFrame DataFrameSubsetVisitors::subset(const LogicalVector& index, const CharacterVector& classes) const {
     int n = index.size();
-    int n_out = std::count(index.begin(), index.end(), TRUE);
-    IntegerVector idx = no_init(n_out);
-    for (int i=0, k=0; i<n; i++) {
+    std::vector<int> idx;
+    idx.reserve(index.length());
+    for (int i=0; i<n; i++) {
       if (index[i] == TRUE) {
-        idx[k++] = i;
+        idx.push_back(i);
       }
     }
     return subset(idx, classes);

--- a/inst/include/dplyr/DataFrameSubsetVisitors.h
+++ b/inst/include/dplyr/DataFrameSubsetVisitors.h
@@ -59,7 +59,7 @@ namespace dplyr {
     }
 
     template <typename Container>
-    DataFrame subset_impl(const Container& index, const CharacterVector& classes, Rcpp::traits::false_type) const {
+    DataFrame subset(const Container& index, const CharacterVector& classes) const {
       List out(nvisitors);
       for (int k=0; k<nvisitors; k++) {
         out[k] = get(k)->subset(index);
@@ -67,28 +67,6 @@ namespace dplyr {
       copy_most_attributes(out, data);
       structure(out, Rf_length(out[0]) , classes);
       return out;
-    }
-
-    template <typename Container>
-    DataFrame subset_impl(const Container& index, const CharacterVector& classes, Rcpp::traits::true_type) const {
-      int n = index.size();
-      int n_out = std::count(index.begin(), index.end(), TRUE);
-      IntegerVector idx = no_init(n_out);
-      for (int i=0, k=0; i<n; i++) {
-        if (index[i] == TRUE) {
-          idx[k++] = i;
-        }
-      }
-      return subset_impl(idx, classes, Rcpp::traits::false_type());
-    }
-
-    template <typename Container>
-    inline DataFrame subset(const Container& index, const CharacterVector& classes) const {
-      return
-        subset_impl(
-          index, classes,
-          typename Rcpp::traits::same_type<Container, LogicalVector>::type()
-        );
     }
 
     inline int size() const {
@@ -116,6 +94,19 @@ namespace dplyr {
     }
 
   };
+
+  template <>
+  inline DataFrame DataFrameSubsetVisitors::subset(const LogicalVector& index, const CharacterVector& classes) const {
+    int n = index.size();
+    int n_out = std::count(index.begin(), index.end(), TRUE);
+    IntegerVector idx = no_init(n_out);
+    for (int i=0, k=0; i<n; i++) {
+      if (index[i] == TRUE) {
+        idx[k++] = i;
+      }
+    }
+    return subset(idx, classes);
+  }
 
   template <typename Index>
   DataFrame subset(DataFrame df, const Index& indices, const SymbolVector& columns, const CharacterVector& classes) {

--- a/inst/include/dplyr/DataFrameSubsetVisitors.h
+++ b/inst/include/dplyr/DataFrameSubsetVisitors.h
@@ -97,9 +97,9 @@ namespace dplyr {
 
   template <>
   inline DataFrame DataFrameSubsetVisitors::subset(const LogicalVector& index, const CharacterVector& classes) const {
-    int n = index.size();
+    const int n = index.size();
     std::vector<int> idx;
-    idx.reserve(index.length());
+    idx.reserve(n);
     for (int i=0; i<n; i++) {
       if (index[i] == TRUE) {
         idx.push_back(i);

--- a/inst/include/dplyr/MatrixColumnSubsetVectorVisitor.h
+++ b/inst/include/dplyr/MatrixColumnSubsetVectorVisitor.h
@@ -40,22 +40,6 @@ namespace dplyr {
       return res;
     }
 
-    inline SEXP subset(const Rcpp::LogicalVector& index) const {
-      int n = output_size(index);
-      int nc = data.ncol();
-      Matrix<RTYPE> res(n, data.ncol());
-      for (int h=0; h<nc; h++) {
-        Column column = res.column(h);
-        Column source_column = const_cast<Matrix<RTYPE>&>(data).column(h);
-
-        for (int i=0, k=0; k<n; k++, i++) {
-          while (index[i] != TRUE) i++;
-          column[k] = source_column[i];
-        }
-      }
-      return res;
-    }
-
     inline SEXP subset(EmptySubset index) const {
       return Matrix<RTYPE>(0, data.ncol());
     }

--- a/inst/include/dplyr/SubsetVectorVisitor.h
+++ b/inst/include/dplyr/SubsetVectorVisitor.h
@@ -7,6 +7,11 @@
 
 namespace dplyr {
 
+  template <typename Container>
+  inline int output_size(const Container& container) {
+    return container.size();
+  }
+
   /**
    * Subset Vector visitor base class, defines the interface
    */

--- a/inst/include/dplyr/SubsetVectorVisitor.h
+++ b/inst/include/dplyr/SubsetVectorVisitor.h
@@ -28,8 +28,6 @@ namespace dplyr {
      */
     virtual SEXP subset(const ChunkIndexMap& index) const = 0;
 
-    virtual SEXP subset(const Rcpp::LogicalVector& index) const = 0;
-
     virtual SEXP subset(EmptySubset) const = 0;
 
     virtual int size() const = 0;

--- a/inst/include/dplyr/SubsetVectorVisitorImpl.h
+++ b/inst/include/dplyr/SubsetVectorVisitorImpl.h
@@ -46,17 +46,6 @@ namespace dplyr {
       return out;
     }
 
-    inline SEXP subset(const Rcpp::LogicalVector& index) const {
-      int n = output_size(index);
-      VECTOR out = Rcpp::no_init(n);
-      for (int i=0, k=0; k<n; k++, i++) {
-        while (index[i] != TRUE) i++;
-        out[k] = vec[i];
-      }
-      copy_most_attributes(out, vec);
-      return out;
-    }
-
     inline SEXP subset(EmptySubset) const {
       VECTOR out(0);
       copy_most_attributes(out, vec);
@@ -131,10 +120,6 @@ namespace dplyr {
       return promote(Parent::subset(map));
     }
 
-    inline SEXP subset(const Rcpp::LogicalVector& index) const {
-      return promote(Parent::subset(index));
-    }
-
     inline SEXP subset(EmptySubset empty) const {
       return promote(Parent::subset(empty));
     }
@@ -203,10 +188,6 @@ namespace dplyr {
     }
 
     virtual SEXP subset(const ChunkIndexMap& index) const {
-      return impl->subset(index);
-    }
-
-    virtual SEXP subset(const Rcpp::LogicalVector& index) const {
       return impl->subset(index);
     }
 

--- a/inst/include/dplyr/VectorVisitorImpl.h
+++ b/inst/include/dplyr/VectorVisitorImpl.h
@@ -10,16 +10,6 @@
 
 namespace dplyr {
 
-  template <typename Container>
-  inline int output_size(const Container& container) {
-    return container.size();
-  }
-
-  template <>
-  inline int output_size<LogicalVector>(const LogicalVector& container) {
-    return std::count(container.begin(), container.end(), TRUE);
-  }
-
   template <int RTYPE> std::string VectorVisitorType();
   template <> inline std::string VectorVisitorType<INTSXP>() {
     return "integer";


### PR DESCRIPTION
- remove unused LogicalVector methods
- use partial specialization instead of traits
- use preallocated integer vector instead of counting
    - this trades memory for speed; a more conservative solution could be used to estimate the final size of the vector (similarly to readr) and to reserve accordingly