### PR TITLE
Fix slice() for zero-column data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.5.0.9000
 
+* Fixed undefined behavior for `slice()` on a zero-column data frame (#2490).
+
 * Fixed segmentation fault after calling `rename()` on an invalid grouped
   data frame (#2031).
 

--- a/inst/include/dplyr/DataFrameSubsetVisitors.h
+++ b/inst/include/dplyr/DataFrameSubsetVisitors.h
@@ -65,7 +65,7 @@ namespace dplyr {
         out[k] = get(k)->subset(index);
       }
       copy_most_attributes(out, data);
-      structure(out, Rf_length(out[0]) , classes);
+      structure(out, output_size(index), classes);
       return out;
     }
 

--- a/inst/include/dplyr/EmptySubset.h
+++ b/inst/include/dplyr/EmptySubset.h
@@ -2,6 +2,11 @@
 #define dplyr_EmptySubset_H
 
 namespace dplyr {
-  class EmptySubset {};
+  class EmptySubset {
+  public:
+    int size() const {
+      return 0;
+    }
+  };
 }
 #endif

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -96,3 +96,10 @@ test_that("slice strips grouped indices (#1405)", {
   expect_equal(nrow(res), 3L)
   expect_equal(attr(res, "indices"), as.list(0:2))
 })
+
+test_that("slice works with zero-column data frames (#2490)", {
+  expect_equal(
+    data_frame(a = 1:3) %>% select(-a) %>% slice(1) %>% nrow,
+    1L
+  )
+})


### PR DESCRIPTION
Fixes #2490.

Builds on top of #2558.