### PR TITLE
Fix performance gap with tidyeval

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     magrittr,
     methods,
     pkgconfig,
-    rlang (>= 0.0.0.9001),
+    rlang (>= 0.0.0.9002),
     R6,
     Rcpp (>= 0.12.6),
     tibble (>= 1.2),
@@ -142,5 +142,5 @@ Collate:
 RoxygenNote: 6.0.1
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 Remotes:
-    hadley/rlang@1eeb44d57c3,
+    hadley/rlang@27d7953,
     tidyverse/glue

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -214,7 +214,7 @@ do.grouped_df <- function(.data, ...) {
 
   for (`_i` in seq_len(n)) {
     for (j in seq_len(m)) {
-      out[[j]][`_i`] <- list(overscope_eval(overscope, args[[j]]))
+      out[[j]][`_i`] <- list(overscope_eval_next(overscope, args[[j]]))
       p$tick()$print()
     }
   }

--- a/R/rowwise.r
+++ b/R/rowwise.r
@@ -99,7 +99,7 @@ do.rowwise_df <- function(.data, ...) {
 
   for (`_i` in seq_len(n)) {
     for (j in seq_len(m)) {
-      out[[j]][`_i`] <- list(overscope_eval(overscope, args[[j]]))
+      out[[j]][`_i`] <- list(overscope_eval_next(overscope, args[[j]]))
       p$tick()$print()
     }
   }

--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -516,7 +516,7 @@ do.tbl_sql <- function(.data, ..., .chunk_size = 1e4L) {
       # Update pronouns within the overscope
       env$. <- env$.data <- cur_chunk
       for (k in seq_len(m)) {
-        out[[k]][i + j] <<- list(overscope_eval(overscope, args[[k]]))
+        out[[k]][i + j] <<- list(overscope_eval_next(overscope, args[[k]]))
         p$tick()$print()
       }
     }
@@ -527,7 +527,7 @@ do.tbl_sql <- function(.data, ..., .chunk_size = 1e4L) {
   if (!is_null(last_group)) {
     env$. <- env$.data <- last_group
     for (k in seq_len(m)) {
-      out[[k]][i + 1] <- list(overscope_eval(overscope, args[[k]]))
+      out[[k]][i + 1] <- list(overscope_eval_next(overscope, args[[k]]))
       p$tick()$print()
     }
   }

--- a/R/translate-sql.r
+++ b/R/translate-sql.r
@@ -135,7 +135,7 @@ translate_sql_ <- function(dots,
     } else {
       overscope <- sql_overscope(x, variant, con, window = window)
       on.exit(overscope_clean(overscope))
-      escape(overscope_eval(overscope, x))
+      escape(overscope_eval_next(overscope, x))
     }
   })
 

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -67,7 +67,7 @@ namespace dplyr {
 
       // Install definitions for formula self-evaluation and unguarding
       Function new_overscope = rlang_object("new_overscope");
-      overscope = new_overscope(bottom, active_env);
+      overscope = new_overscope(bottom, active_env, env);
 
       has_overscope = true;
     }
@@ -212,13 +212,7 @@ namespace dplyr {
 
       if (TYPEOF(call) == LANGSXP || TYPEOF(call) == SYMSXP) {
         LOG_VERBOSE << "performing evaluation in overscope";
-        static Function overscope_eval = rlang_object("overscope_eval");
-
-        // FIXME: The class should be constructed around a quosure
-        //        rather than call + env
-        Shield<SEXP> quo(quosure(call, env));
-
-        return overscope_eval(hybrid_env.get_overscope(), (SEXP) quo);
+        return Rcpp_eval(call, hybrid_env.get_overscope());
       }
       return call;
     }


### PR DESCRIPTION
I go from 6s to 1.4s with the `mutate.dplyr_df` test case. This could still be divided by 2 by using `Rf_eval()` instead of `Rcpp_eval()` once we get proper stack unwinding.