### PR TITLE
Fix colwise genericity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # dplyr 0.5.0.9000
 
+* The scoped verbs taking predicates (`mutate_if()`, `summarise_if()`,
+  etc) now support S3 objects and lazy tables. S3 objects should
+  implement methods for `length()`, `[[` and `tbl_vars()`. For lazy
+  tables, the first 100 rows are collected and the predicate is
+  applied on this subset of the data. This is robust for the common
+  case of checking the type of a column (#2129).
+
 * The performance of colwise verbs like `mutate_all()` is now back to
   where it was in `mutate_each()`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,12 @@
   (#2056), and also for zero-column data frames (#2175).
 
 * `mutate()` recycles list columns of length 1 (#2171).
+* Databases and lazy tables are now compatible with `_if()` variants
+  such as `mutate_if()`. The predicates are applied on the first 10000
+  rows.
+
+* The `_if()` variants such as `mutate_if()` are now compatible with
+  objects implementing `length()` and `[[` methods.
 
 * Fixed very rare case of false match during join (#2515).
 

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -90,7 +90,7 @@ summarise_if <- function(.tbl, .predicate, .funs, ...) {
   if (inherits(.tbl, "tbl_lazy")) {
     abort("Conditional colwise operations currently require local sources")
   }
-  vars <- probe_colwise_names(.tbl, .predicate)
+  vars <- tbl_if_syms(.tbl, .predicate)
   funs <- as_fun_list(.funs, enquo(.funs), ...)
   funs <- apply_vars(funs, vars, .tbl)
   summarise(.tbl, !!! funs)
@@ -102,29 +102,16 @@ mutate_if <- function(.tbl, .predicate, .funs, ...) {
   if (inherits(.tbl, "tbl_lazy")) {
     abort("Conditional colwise operations currently require local sources")
   }
-  vars <- probe_colwise_names(.tbl, .predicate)
+  vars <- tbl_if_syms(.tbl, .predicate)
   funs <- as_fun_list(.funs, enquo(.funs), ...)
   funs <- apply_vars(funs, vars, .tbl)
   mutate(.tbl, !!! funs)
 }
 
-probe_colwise_names <- function(tbl, p, ...) {
-  if (is_logical(p)) {
-    stopifnot(length(p) == length(tbl))
-    selected <- p
-  } else {
-    selected <- map_lgl(tbl, p, ...)
-  }
-
-  vars <- tbl_vars(tbl)
-  vars <- vars[selected]
-  syms(vars)
-}
-
 #' @rdname summarise_all
 #' @export
 summarise_at <- function(.tbl, .cols, .funs, ...) {
-  vars <- select_colwise_names(.tbl, .cols)
+  vars <- tbl_at_syms(.tbl, .cols)
   funs <- as_fun_list(.funs, enquo(.funs), ...)
   funs <- apply_vars(funs, vars, .tbl)
   summarise(.tbl, !!! funs)
@@ -133,7 +120,7 @@ summarise_at <- function(.tbl, .cols, .funs, ...) {
 #' @rdname summarise_all
 #' @export
 mutate_at <- function(.tbl, .cols, .funs, ...) {
-  vars <- select_colwise_names(.tbl, .cols)
+  vars <- tbl_at_syms(.tbl, .cols)
   funs <- as_fun_list(.funs, enquo(.funs), ...)
   funs <- apply_vars(funs, vars, .tbl)
   mutate(.tbl, !!! funs)
@@ -166,7 +153,7 @@ vars <- function(...) {
 }
 is_col_list <- function(cols) inherits(cols, "col_list")
 
-select_colwise_names <- function(tbl, cols) {
+tbl_at_syms <- function(tbl, cols) {
   vars <- tbl_vars(tbl)
 
   if (is_character(cols)) {
@@ -176,10 +163,23 @@ select_colwise_names <- function(tbl, cols) {
   } else if (is.numeric(cols)) {
     selected <- syms(vars[cols])
   } else {
-    abort(".cols should be a character/numeric vector or a columns object")
+    abort("`.cols` should be a character/numeric vector or a columns object")
   }
 
   selected
+}
+
+tbl_if_syms <- function(tbl, p, ...) {
+  if (is_logical(p)) {
+    stopifnot(length(p) == length(tbl))
+    selected <- p
+  } else {
+    selected <- map_lgl(tbl, p, ...)
+  }
+
+  vars <- tbl_vars(tbl)
+  vars <- vars[selected]
+  syms(vars)
 }
 
 

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -87,9 +87,6 @@ mutate_all <- function(.tbl, .funs, ...) {
 #' @rdname summarise_all
 #' @export
 summarise_if <- function(.tbl, .predicate, .funs, ...) {
-  if (inherits(.tbl, "tbl_lazy")) {
-    abort("Conditional colwise operations currently require local sources")
-  }
   vars <- tbl_if_syms(.tbl, .predicate)
   funs <- as_fun_list(.funs, enquo(.funs), ...)
   funs <- apply_vars(funs, vars, .tbl)
@@ -99,9 +96,6 @@ summarise_if <- function(.tbl, .predicate, .funs, ...) {
 #' @rdname summarise_all
 #' @export
 mutate_if <- function(.tbl, .predicate, .funs, ...) {
-  if (inherits(.tbl, "tbl_lazy")) {
-    abort("Conditional colwise operations currently require local sources")
-  }
   vars <- tbl_if_syms(.tbl, .predicate)
   funs <- as_fun_list(.funs, enquo(.funs), ...)
   funs <- apply_vars(funs, vars, .tbl)
@@ -172,8 +166,10 @@ tbl_at_syms <- function(tbl, cols) {
 
 # Requires tbl_vars(), `[[`() and length() methods
 tbl_if_syms <- function(tbl, p, ...) {
+  vars <- tbl_vars(tbl)
+
   if (is_logical(p)) {
-    stopifnot(length(p) == length(tbl))
+    stopifnot(length(p) == length(vars))
     selected <- p
   } else {
     if (inherits(tbl, "tbl_lazy")) {
@@ -189,7 +185,6 @@ tbl_if_syms <- function(tbl, p, ...) {
     }
   }
 
-  vars <- tbl_vars(tbl)
   vars <- vars[selected]
   syms(vars)
 }

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -174,8 +174,8 @@ tbl_if_syms <- function(tbl, p, ...) {
   }
 
   if (inherits(tbl, "tbl_lazy")) {
-    inform("Applying predicate on the first 10 000 rows")
-    tibble <- collect(tbl, n = 1e4L)
+    inform("Applying predicate on the first 100 rows")
+    tibble <- collect(tbl, n = 100)
   } else {
     tibble <- tbl
   }

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -170,25 +170,24 @@ tbl_if_syms <- function(tbl, p, ...) {
 
   if (is_logical(p)) {
     stopifnot(length(p) == length(vars))
-    selected <- p
-  } else {
-    if (inherits(tbl, "tbl_lazy")) {
-      tibble <- collect(tbl, n = 1e4L)
-    } else {
-      tibble <- tbl
-    }
+    return(syms(vars[p]))
+  }
 
-    n <- length(tibble)
-    selected <- lgl_len(n)
-    for (i in seq_len(n)) {
-      selected[[i]] <- p(tibble[[i]], ...)
-    }
+  if (inherits(tbl, "tbl_lazy")) {
+    tibble <- collect(tbl, n = 1e4L)
+  } else {
+    tibble <- tbl
+  }
+
+  n <- length(tibble)
+  selected <- lgl_len(n)
+  for (i in seq_len(n)) {
+    selected[[i]] <- p(tibble[[i]], ...)
   }
 
   vars <- vars[selected]
   syms(vars)
 }
-
 
 apply_vars <- function(funs, vars, tbl) {
   stopifnot(is_fun_list(funs))

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -153,6 +153,7 @@ vars <- function(...) {
 }
 is_col_list <- function(cols) inherits(cols, "col_list")
 
+# Requires tbl_vars() method
 tbl_at_syms <- function(tbl, cols) {
   vars <- tbl_vars(tbl)
 
@@ -169,12 +170,23 @@ tbl_at_syms <- function(tbl, cols) {
   selected
 }
 
+# Requires tbl_vars(), `[[`() and length() methods
 tbl_if_syms <- function(tbl, p, ...) {
   if (is_logical(p)) {
     stopifnot(length(p) == length(tbl))
     selected <- p
   } else {
-    selected <- map_lgl(tbl, p, ...)
+    if (inherits(tbl, "tbl_lazy")) {
+      tibble <- collect(tbl, n = 1e4L)
+    } else {
+      tibble <- tbl
+    }
+
+    n <- length(tibble)
+    selected <- lgl_len(n)
+    for (i in seq_len(n)) {
+      selected[[i]] <- p(tibble[[i]], ...)
+    }
   }
 
   vars <- tbl_vars(tbl)

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -174,6 +174,7 @@ tbl_if_syms <- function(tbl, p, ...) {
   }
 
   if (inherits(tbl, "tbl_lazy")) {
+    inform("Applying predicate on the first 10 000 rows")
     tibble <- collect(tbl, n = 1e4L)
   } else {
     tibble <- tbl

--- a/R/manip.r
+++ b/R/manip.r
@@ -364,7 +364,7 @@ select_if <- function(.data, .predicate, ...) {
   if (inherits(.data, "tbl_lazy")) {
     abort("Selection with predicate currently require local sources")
   }
-  vars <- probe_colwise_names(.data, .predicate, ...)
+  vars <- tbl_if_syms(.data, .predicate, ...)
   vars <- ensure_grouped_vars(vars, .data, notify = FALSE)
   select(.data, !!! syms(vars))
 }

--- a/tests/testthat/test-colwise.R
+++ b/tests/testthat/test-colwise.R
@@ -100,7 +100,7 @@ test_that("lazy tables support colwise variants", {
   expected <- as.character(iris$Species[1:10])
   for (tbl in tbls) {
     if (inherits(tbl, "tbl_lazy")) {
-      tbl <- mutate_if(tbl, is.factor, as.character)
+      expect_message(tbl <- mutate_if(tbl, is.factor, as.character), "10 000")
       expect_identical(collect(tbl)$Species, expected)
     }
   }

--- a/tests/testthat/test-colwise.R
+++ b/tests/testthat/test-colwise.R
@@ -100,7 +100,7 @@ test_that("lazy tables support colwise variants", {
   expected <- as.character(iris$Species[1:10])
   for (tbl in tbls) {
     if (inherits(tbl, "tbl_lazy")) {
-      expect_message(tbl <- mutate_if(tbl, is.factor, as.character), "10 000")
+      expect_message(tbl <- mutate_if(tbl, is.factor, as.character), "on the first 100 rows")
       expect_identical(collect(tbl)$Species, expected)
     }
   }

--- a/tests/testthat/test-colwise.R
+++ b/tests/testthat/test-colwise.R
@@ -94,6 +94,26 @@ test_that("funs() works with namespaced calls", {
   expect_identical(summarise_all(mtcars, funs(base::mean)), summarise_all(mtcars, funs(mean(.))))
 })
 
+test_that("lazy tables support colwise variants", {
+  tbls <- test_load(iris[1:10, ])
+
+  expected <- as.character(iris$Species[1:10])
+  for (tbl in tbls) {
+    if (inherits(tbl, "tbl_lazy")) {
+      tbl <- mutate_if(tbl, is.factor, as.character)
+      expect_identical(collect(tbl)$Species, expected)
+    }
+  }
+
+  expected <- mean(iris$Sepal.Length[1:10])
+  for (tbl in tbls) {
+    if (inherits(tbl, "tbl_lazy")) {
+      tbl <- summarise_at(tbl, "Sepal.Length", mean)
+      expect_equal(collect(tbl)$Sepal.Length, expected)
+    }
+  }
+})
+
 
 # Deprecated ---------------------------------------------------------
 


### PR DESCRIPTION
Includes #2569, fixes #2129 

- Lazy tables are first collected (100 first rows)
- S3 vectors are supported if they implement `tbl_vars()`, `length()` and `[[`.