### PR TITLE
Consistent join result when there are rows in right table with no match in left table

### DIFF
--- a/R/lazy-ops.R
+++ b/R/lazy-ops.R
@@ -190,7 +190,7 @@ op_vars.op_single <- function(op) {
 }
 #' @export
 op_vars.op_join <- function(op) {
-  unlist(op$args$vars, use.names = FALSE)
+  op$args$vars$alias
 }
 #' @export
 op_vars.op_semi_join <- function(op) {

--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -110,10 +110,19 @@ sql_join.default <- function(con, x, y, vars, type = "inner", by = NULL, ...) {
     stop("Unknown join type:", type, call. = FALSE)
   )
 
-  select <- sql_vector(c(
-    sql_as(con, names(vars$x), vars$x, table = "TBL_LEFT"),
-    sql_as(con, names(vars$y), vars$y, table = "TBL_RIGHT")
-  ), collapse = ", ", parens = FALSE)
+  select <- sql_vector(
+    paste0(
+      sql_if_vars_x_and_y(vars, "COALESCE("),
+      sql_if_vars_x(vars, sql_table_prefix(con, vars$x, table = "TBL_LEFT")),
+      sql_if_vars_x_and_y(vars, ", "),
+      sql_if_vars_y(vars, sql_table_prefix(con, vars$y, table = "TBL_RIGHT")),
+      sql_if_vars_x_and_y(vars, ")"),
+      sql(" AS "),
+      sql_escape_ident(con, vars$alias)
+    ),
+    collapse = ", ",
+    parens = FALSE
+  )
 
   on <- sql_vector(
     paste0(
@@ -155,6 +164,16 @@ sql_table_prefix <- function(con, var, table = NULL) {
     var
   }
 
+}
+
+sql_if_vars_x <- function(vars, sql) {
+  ifelse(!is.na(vars$x), sql, "")
+}
+sql_if_vars_y <- function(vars, sql) {
+  ifelse(!is.na(vars$y), sql, "")
+}
+sql_if_vars_x_and_y <- function(vars, sql) {
+  ifelse(!is.na(vars$x) & !is.na(vars$y), sql, "")
 }
 
 #' @export

--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -120,8 +120,9 @@ sql_join.default <- function(con, x, y, vars, type = "inner", by = NULL, ...) {
       sql(" AS "),
       sql_escape_ident(con, vars$alias)
     ),
+    parens = FALSE,
     collapse = ", ",
-    parens = FALSE
+    con = con
   )
 
   on <- sql_vector(

--- a/R/sql-query.R
+++ b/R/sql-query.R
@@ -87,7 +87,7 @@ join_query <- function(x, y, vars, type = "inner", by = NULL, suffix = c(".x", "
 
 
 # Returns NULL if variables don't need to be renamed
-join_vars <- function(x_names, y_names, by, suffix = c(".x", ".y")) {
+join_vars <- function(x_names, y_names, type, by, suffix = c(".x", ".y")) {
   # Remove join keys from y
   y_names <- setdiff(y_names, by$y)
 
@@ -103,7 +103,14 @@ join_vars <- function(x_names, y_names, by, suffix = c(".x", ".y")) {
   y_new <- y_names
   y_new[y_match] <- paste0(y_names[y_match], suffix$y)
 
-  list(x = setNames(x_new, x_names), y = setNames(y_new, y_names))
+  x_x <- x_names
+  x_y <- by$y[match(x_names, by$x)]
+  x_x[type == "right" & !is.na(x_y)] <- NA
+
+  y_x <- rep_len(NA, length(y_names))
+  y_y <- y_names
+
+  list(alias = c(x_new, y_new), x = c(x_x, y_x), y = c(x_y, y_y))
 }
 
 

--- a/R/tbl-lazy.R
+++ b/R/tbl-lazy.R
@@ -172,7 +172,7 @@ add_op_join <- function(x, y, type, by = NULL, copy = FALSE,
     indexes = if (auto_index) list(by$y)
   )
 
-  vars <- join_vars(op_vars(x), op_vars(y), by = by, suffix = suffix)
+  vars <- join_vars(op_vars(x), op_vars(y), type = type, by = by, suffix = suffix)
 
   x$ops <- op_double("join", x, y, args = list(
     vars = vars,

--- a/R/translate-sql-base.r
+++ b/R/translate-sql-base.r
@@ -122,6 +122,10 @@ base_scalar <- sql_translator(
     build_sql("((", x, ") IS NULL)")
   },
   na_if = sql_prefix("NULL_IF", 2),
+  coalesce = function(...) {
+    vars <- sql_vector(list(...), parens = FALSE, collapse = ", ")
+    build_sql("coalesce(", vars, ")")
+  },
 
   as.numeric = function(x) build_sql("CAST(", x, " AS NUMERIC)"),
   as.integer = function(x) build_sql("CAST(", x, " AS INTEGER)"),

--- a/tests/testthat/test-sql-join-right-full.R
+++ b/tests/testthat/test-sql-join-right-full.R
@@ -1,0 +1,135 @@
+context("SQL: right and full joins")
+
+test_that("right join on key column with same name in both tables", {
+  test_f <- function(tbl_left, tbl_right) {
+    res <-
+      right_join(tbl_left, tbl_right, by = "x") %>%
+      arrange(x, y, z) %>%
+      collect()
+    expect_equivalent(as.data.frame(res),
+                 data.frame(
+                   x = c(1L, 2L, 3L, 5L),
+                   y = c(1L, 2L, 3L, NA),
+                   z = c(1L, 2L, 3L, 4L)
+                 ))
+  }
+
+  df_left <- data_frame(x = 1L:4L, y = 1L:4L)
+  df_right <- data_frame(x = c(1L:3L, 5L), z = 1L:4L)
+  # SQLite doesn't support right joins
+  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_right <- test_load(df_right, ignore = c("sqlite"))
+  mapply(test_f, tbls_left, tbls_right)
+})
+
+test_that("full join on key column with same name in both tables", {
+  test_f <- function(tbl_left, tbl_right) {
+    res <-
+      full_join(tbl_left, tbl_right, by = "x") %>%
+      arrange(x, y, z) %>%
+      collect()
+    expect_equivalent(as.data.frame(res),
+                      data.frame(
+                        x = c(1L, 2L, 3L, 4L, 5L),
+                        y = c(1L, 2L, 3L, 4L, NA),
+                        z = c(1L, 2L, 3L, NA, 4L)
+                      ))
+  }
+
+  df_left <- data_frame(x = 1L:4L, y = 1L:4L)
+  df_right <- data_frame(x = c(1L:3L, 5L), z = 1L:4L)
+  # SQLite and MySQL don't support full joins
+  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_right <- test_load(df_right, ignore = c("sqlite", "mysql"))
+  mapply(test_f, tbls_left, tbls_right)
+})
+
+test_that("right join on key column with different names", {
+  test_f <- function(tbl_left, tbl_right) {
+    res <-
+      right_join(tbl_left, tbl_right, by = c("xl" = "xr")) %>%
+      arrange(xl, y, z) %>%
+      collect()
+    expect_equivalent(as.data.frame(res),
+                      data.frame(
+                        xl = c(1L, 2L, 3L, 5L),
+                        y = c(1L, 2L, 3L, NA),
+                        z = c(1L, 2L, 3L, 4L)
+                      ))
+  }
+
+  df_left <- data_frame(xl = 1L:4L, y = 1L:4L)
+  df_right <- data_frame(xr = c(1L:3L, 5L), z = 1L:4L)
+  # SQLite doesn't support right joins
+  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_right <- test_load(df_right, ignore = c("sqlite"))
+  mapply(test_f, tbls_left, tbls_right)
+})
+
+test_that("full join on key column with different names", {
+  test_f <- function(tbl_left, tbl_right) {
+    res <-
+      full_join(tbl_left, tbl_right, by = c("xl" = "xr")) %>%
+      arrange(xl, y, z) %>%
+      collect()
+    expect_equivalent(as.data.frame(res),
+                      data.frame(
+                        xl = c(1L, 2L, 3L, 4L, 5L),
+                        y = c(1L, 2L, 3L, 4L, NA),
+                        z = c(1L, 2L, 3L, NA, 4L)
+                      ))
+  }
+
+  df_left <- data_frame(xl = 1L:4L, y = 1L:4L)
+  df_right <- data_frame(xr = c(1L:3L, 5L), z = 1L:4L)
+  # SQLite and MySQL don't support full joins
+  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_right <- test_load(df_right, ignore = c("sqlite", "mysql"))
+  mapply(test_f, tbls_left, tbls_right)
+})
+
+test_that("right natural join", {
+  test_f <- function(tbl_left, tbl_right) {
+    res <-
+      right_join(tbl_left, tbl_right) %>%
+      arrange(x, y, z, w) %>%
+      collect()
+    expect_equivalent(as.data.frame(res),
+                      data.frame(
+                        x = c(1L, 2L, 3L, 5L),
+                        y = c(1L, 2L, 3L, 4L),
+                        z = c(1L, 2L, 3L, NA),
+                        w = c(1L, 2L, 3L, 4L)
+                      ))
+  }
+
+  df_left <- data_frame(x = 1L:4L, y = 1L:4L, w = 1L:4L)
+  df_right <- data_frame(x = c(1L:3L, 5L), y=1L:4L, z = 1L:4L)
+  # SQLite doesn't support right joins
+  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_right <- test_load(df_right, ignore = c("sqlite"))
+  mapply(test_f, tbls_left, tbls_right)
+})
+
+test_that("full natural join", {
+  test_f <- function(tbl_left, tbl_right) {
+    res <-
+      full_join(tbl_left, tbl_right) %>%
+      arrange(x, y, z, w) %>%
+      collect()
+    expect_equivalent(as.data.frame(res),
+                      data.frame(
+                        x = c(1L, 2L, 3L, 4L, 5L),
+                        y = c(1L, 2L, 3L, 4L, 4L),
+                        z = c(1L, 2L, 3L, 4L, NA),
+                        w = c(1L, 2L, 3L, NA, 4L)
+                      ))
+  }
+
+  df_left <- data_frame(x = 1L:4L, y = 1L:4L, w = 1L:4L)
+  df_right <- data_frame(x = c(1L:3L, 5L), y=1L:4L, z = 1L:4L)
+  # SQLite and MySQL don't support full joins
+  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_right <- test_load(df_right, ignore = c("sqlite", "mysql"))
+  mapply(test_f, tbls_left, tbls_right)
+})

--- a/tests/testthat/test-sql-join-right-full.R
+++ b/tests/testthat/test-sql-join-right-full.R
@@ -39,7 +39,7 @@ test_that("full join on key column with same name in both tables", {
   df_left <- data_frame(x = 1L:4L, y = 1L:4L)
   df_right <- data_frame(x = c(1L:3L, 5L), z = 1L:4L)
   # SQLite and MySQL don't support full joins
-  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_left <- test_load(df_left, ignore = c("sqlite", "mysql"))
   tbls_right <- test_load(df_right, ignore = c("sqlite", "mysql"))
   mapply(test_f, tbls_left, tbls_right)
 })
@@ -83,7 +83,7 @@ test_that("full join on key column with different names", {
   df_left <- data_frame(xl = 1L:4L, y = 1L:4L)
   df_right <- data_frame(xr = c(1L:3L, 5L), z = 1L:4L)
   # SQLite and MySQL don't support full joins
-  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_left <- test_load(df_left, ignore = c("sqlite", "mysql"))
   tbls_right <- test_load(df_right, ignore = c("sqlite", "mysql"))
   mapply(test_f, tbls_left, tbls_right)
 })
@@ -129,7 +129,7 @@ test_that("full natural join", {
   df_left <- data_frame(x = 1L:4L, y = 1L:4L, w = 1L:4L)
   df_right <- data_frame(x = c(1L:3L, 5L), y=1L:4L, z = 1L:4L)
   # SQLite and MySQL don't support full joins
-  tbls_left <- test_load(df_left, ignore = c("sqlite"))
+  tbls_left <- test_load(df_left, ignore = c("sqlite", "mysql"))
   tbls_right <- test_load(df_right, ignore = c("sqlite", "mysql"))
   mapply(test_f, tbls_left, tbls_right)
 })


### PR DESCRIPTION
This is #2578 take two.

The options are removed, and the important logic is now in `join_vars()`. The list returned by `join_vars()` has a different structure than before: the list (`vars`) contains three parallel character vectors named `alias`, `x`, and `y`. `vars$alias` contains the column names from both tables as they will appear in the join result. `vars$x` contains the names of the corresponding columns in the left table, and `vars$y` contains the names of the corresponding columns in the right table. 

The absence or presence of `NA` values in each position of `vars$x` and `vars$y` is used to indicate which table(s) each column in `vars$alias` should be returned from. If both values in a position are non-`NA` (which happens only in full joins), that triggers a `COALESCE()` in the SQL for that column.

`sql_join.default()` uses a vectorized `paste0()` to create the `select` SQL. It calls three vectorized helper functions which test for the `NA` conditions to determine whether or not to include the different parts of the SQL for each column.