### PR TITLE
Get rid of skip() calls in tests

### DIFF
--- a/tests/testthat/test-do.R
+++ b/tests/testthat/test-do.R
@@ -46,8 +46,10 @@ test_that("empty results preserved (#597)", {
   blankdf <- function(x) data.frame(blank = numeric(0))
 
   dat <- data.frame(a = 1:2, b = factor(1:2))
-  dat %>% group_by(b) %>% do(blankdf(.))
-
+  expect_equal(
+    dat %>% group_by(b) %>% do(blankdf(.)),
+    data.frame(b = factor(integer(), levels = 1:2), blank = numeric())
+  )
 })
 
 test_that("empty inputs give empty outputs (#597)", {

--- a/tests/testthat/test-hybrid-traverse.R
+++ b/tests/testthat/test-hybrid-traverse.R
@@ -271,23 +271,6 @@ test_hybrid <- function(grouping) {
     )
   })
 
-  test_that("filter understands .env in a pipe (#1469)", {
-    skip("Currently failing")
-
-    b <- 2L
-
-    expect_equal(
-      test_df %>%
-        grouping %>%
-        filter(b < .env$b) %>%
-        select(-e),
-      test_df %>%
-        grouping %>%
-        filter(b < 2) %>%
-        select(-e)
-    )
-  })
-
   test_that("filter understands get(..., .env) in a pipe (#1469)", {
     b <- 2L
 
@@ -363,23 +346,6 @@ test_hybrid <- function(grouping) {
     )
   })
 
-  test_that("mutate understands .env in a pipe (#1469)", {
-    skip("Currently failing")
-
-    b <- 2L
-
-    expect_equal(
-      test_df %>%
-        grouping %>%
-        mutate(f = .env$b) %>%
-        select(-e),
-      test_df %>%
-        grouping %>%
-        mutate(f = 2L) %>%
-        select(-e)
-    )
-  })
-
   test_that("mutate understands get(..., .env) in a pipe (#1469)", {
     b <- 2L
 
@@ -437,21 +403,6 @@ test_hybrid <- function(grouping) {
         test_df %>%
           grouping,
         f = .env$b),
-      test_df %>%
-        grouping %>%
-        summarise(f = 2L)
-    )
-  })
-
-  test_that("summarise understands .env in a pipe (#1469)", {
-    skip("Currently failing")
-
-    b <- 2L
-
-    expect_equal(
-      test_df %>%
-        grouping %>%
-        summarise(f = .env$b),
       test_df %>%
         grouping %>%
         summarise(f = 2L)

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -10,6 +10,9 @@ test_that("hybrid evaluation environment is cleaned up (#2358)", {
   expect_environments_clean(df$f[[1]])
   expect_environments_clean(df$g[[1]])
   expect_environments_clean(df$h[[1]])
+
+  # Avoids "Empty test" message
+  expect_true(TRUE)
 })
 
 test_that("n() and n_distinct() work", {

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -58,21 +58,6 @@ test_that("n() and n_distinct() work", {
     n_distinct(), a = 1:5,
     error = "need at least one column"
   )
-
-  skip("Currently failing (external var)")
-  c <- 1:3
-  check_not_hybrid_result(
-    n_distinct(c), a = 1:5,
-    expected = 3L, test_eval = FALSE
-  )
-  check_not_hybrid_result(
-    n_distinct(a, c), a = 1:3,
-    expected = 3L, test_eval = FALSE
-  )
-  check_not_hybrid_result(
-    n_distinct(a, b, na.rm = 1), a = rep(1L, 3), b = c(1, 1, NA),
-    expected = 1L
-  )
 })
 
 test_that("%in% works (#192)", {
@@ -96,42 +81,6 @@ test_that("%in% works (#192)", {
   check_not_hybrid_result(
     list(c %in% 1:3), a = as.numeric(2:4),
     expected = list(c(TRUE, TRUE, FALSE))
-  )
-
-  skip("Currently failing (constfold)")
-  check_hybrid_result(
-    list(a %in% 1:3), a = 2:4,
-    expected = list(c(TRUE, TRUE, FALSE))
-  )
-  check_hybrid_result(
-    list(a %in% as.numeric(1:3)), a = as.numeric(2:4),
-    expected = list(c(TRUE, TRUE, FALSE))
-  )
-  check_hybrid_result(
-    list(a %in% letters[1:3]), a = letters[2:4],
-    expected = list(c(TRUE, TRUE, FALSE))
-  )
-  check_hybrid_result(
-    list(a %in% c(TRUE, FALSE)), a = c(TRUE, FALSE, NA),
-    expected = list(c(TRUE, TRUE, FALSE))
-  )
-
-  skip("Currently failing")
-  check_hybrid_result(
-    list(a %in% NA_integer_), a = c(2:4, NA),
-    expected = list(c(FALSE, FALSE, FALSE, TRUE))
-  )
-  check_hybrid_result(
-    list(a %in% NA_real_), a = as.numeric(c(2:4, NA)),
-    expected = list(c(FALSE, FALSE, FALSE, TRUE))
-  )
-  check_hybrid_result(
-    list(a %in% NA_character_), a = c(letters[2:4], NA),
-    expected = list(c(FALSE, FALSE, FALSE, TRUE))
-  )
-  check_hybrid_result(
-    list(a %in% NA), a = c(TRUE, FALSE, NA),
-    expected = list(c(FALSE, FALSE, TRUE))
   )
 })
 
@@ -251,59 +200,6 @@ test_that("min() and max() work", {
     expected = Inf,
     test_eval = FALSE
   )
-
-  skip("Currently failing (constfold)")
-  check_hybrid_result(
-    min(a, na.rm = (1 == 0)), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    max(a, na.rm = (1 == 0)), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    min(a, na.rm = (1 == 1)), a = c(1:5, NA),
-    expected = 1L
-  )
-  check_hybrid_result(
-    max(a, na.rm = (1 == 1)), a = c(1:5, NA),
-    expected = 5L
-  )
-
-  check_hybrid_result(
-    min(a, na.rm = pi != pi), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    max(a, na.rm = pi != pi), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    min(a, na.rm = pi == pi), a = c(1:5, NA),
-    expected = 1L
-  )
-  check_hybrid_result(
-    max(a, na.rm = pi == pi), a = c(1:5, NA),
-    expected = 5L
-  )
-
-  skip("Currently failing")
-  check_hybrid_result(
-    min(a, na.rm = F), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    max(a, na.rm = F), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    min(a, na.rm = T), a = c(1:5, NA),
-    expected = 1L
-  )
-  check_hybrid_result(
-    max(a, na.rm = T), a = c(1:5, NA),
-    expected = 5L
-  )
 })
 
 test_that("first(), last(), and nth() work", {
@@ -377,17 +273,6 @@ test_that("first(), last(), and nth() work", {
     first(a, order_by = b), a = 1:5, b = 5:1,
     expected = 5L
   )
-
-  skip("Currently failing (constfold)")
-  check_hybrid_result(
-    nth(a, 1 + 2), a = letters[1:5],
-    expected = "c"
-  )
-
-  check_hybrid_result(
-    nth(a, -4), a = 1:5,
-    expected = 2L
-  )
 })
 
 test_that("lead() and lag() work", {
@@ -454,61 +339,6 @@ test_that("lead() and lag() work", {
     list(lag(a, v[1])), a = 1:5,
     expected = list(c(NA, 1:4))
   )
-
-  skip("Currently failing (constfold)")
-  check_hybrid_result(
-    list(lead(a, 1L + 2L)), a = 1:5,
-    expected = list(c(4:5, NA, NA, NA))
-  )
-  check_hybrid_result(
-    list(lag(a, 4L - 2L)), a = as.numeric(1:5),
-    expected = list(c(NA, NA, as.numeric(1:3)))
-  )
-
-  check_not_hybrid_result(
-    list(lead(a, default = 2 + 4)), a = 1:5,
-    expected = list(as.numeric(2:6))
-  )
-  check_not_hybrid_result(
-    list(lag(a, default = 3L - 3L)), a = as.numeric(1:5),
-    expected = list(as.numeric(0:4))
-  )
-
-  check_hybrid_result(
-    list(lead(a, 1 + 2)), a = 1:5,
-    expected = list(c(4:5, NA, NA, NA))
-  )
-  check_hybrid_result(
-    list(lag(a, 4 - 2)), a = as.numeric(1:5),
-    expected = list(c(NA, NA, as.numeric(1:3)))
-  )
-
-  check_hybrid_result(
-    list(lead(a, default = 2L + 4L)), a = 1:5,
-    expected = list(2:6)
-  )
-  check_hybrid_result(
-    list(lag(a, default = 3L - 3L)), a = 1:5,
-    expected = list(0:4)
-  )
-
-  check_hybrid_result(
-    list(lead(a, def = 2L + 4L)), a = 1:5,
-    expected = list(2:6)
-  )
-  check_hybrid_result(
-    list(lag(a, def = 3L - 3L)), a = 1:5,
-    expected = list(0:4)
-  )
-
-  check_hybrid_result(
-    list(lead(a, 2, 2L + 4L)), a = 1:5,
-    expected = list(c(3:6, 6L))
-  )
-  check_hybrid_result(
-    list(lag(a, 3, 3L - 3L)), a = 1:5,
-    expected = list(c(0L, 0L, 0:2))
-  )
 })
 
 test_that("mean(), var(), sd() and sum() work", {
@@ -560,74 +390,9 @@ test_that("mean(), var(), sd() and sum() work", {
     expected = 1
   )
 
-  skip("Currently failing, sqrt(NA) in sd()")
   check_hybrid_result(
     sd(a), a = c(1:3, NA),
     expected = NA_real_
-  )
-
-  skip("Currently failing")
-  check_hybrid_result(
-    mean(a, na.rm = (1 == 0)), a = c(1:5, NA),
-    expected = NA_real_
-  )
-  check_hybrid_result(
-    var(a, na.rm = (1 == 0)), a = c(1:3, NA),
-    expected = NA_real_
-  )
-  check_hybrid_result(
-    sd(a, na.rm = (1 == 0)), a = c(1:3, NA),
-    expected = NA_real_
-  )
-  check_hybrid_result(
-    sum(a, na.rm = (1 == 0)), a = c(1:5, NA),
-    expected = NA_integer_
-  )
-  check_hybrid_result(
-    sum(a, na.rm = (1 == 0)), a = c(as.numeric(1:5), NA),
-    expected = NA_real_
-  )
-
-  check_hybrid_result(
-    mean(a, na.rm = (1 == 1)), a = c(1:5, NA),
-    expected = 3
-  )
-  check_hybrid_result(
-    var(a, na.rm = (1 == 1)), a = c(1:3, NA),
-    expected = 1
-  )
-  check_hybrid_result(
-    sd(a, na.rm = (1 == 1)), a = c(1:3, NA),
-    expected = 1
-  )
-  check_hybrid_result(
-    sum(a, na.rm = (1 == 1)), a = c(1:5, NA),
-    expected = 15L
-  )
-  check_hybrid_result(
-    sum(a, na.rm = (1 == 1)), a = c(as.numeric(1:5), NA),
-    expected = 15
-  )
-
-  check_hybrid_result(
-    mean(na.rm = (1 == 1), a), a = c(1:5, NA),
-    expected = 3
-  )
-  check_hybrid_result(
-    var(na.rm = (1 == 1), a), a = c(1:3, NA),
-    expected = 1
-  )
-  check_hybrid_result(
-    sd(na.rm = (1 == 1), a), a = c(1:3, NA),
-    expected = 1
-  )
-  check_hybrid_result(
-    sum(na.rm = (1 == 1), a), a = c(1:5, NA),
-    expected = 15L
-  )
-  check_hybrid_result(
-    sum(na.rm = (1 == 1), a), a = c(as.numeric(1:5), NA),
-    expected = 15
   )
 })
 
@@ -707,20 +472,6 @@ test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and 
     ntile("a", 2), a = 5:1,
     expected = 1L
   )
-
-  skip("Currently failing (constfold)")
-  check_hybrid_result(
-    list(ntile(a, 1 + 2)), a = c(1, 3, 2, 3, 1),
-    expected = list(c(1L, 2L, 2L, 3L, 1L))
-  )
-  check_hybrid_result(
-    list(ntile(a, 1L + 2L)), a = c(1, 3, 2, 3, 1),
-    expected = list(c(1L, 2L, 2L, 3L, 1L))
-  )
-  check_hybrid_result(
-    list(ntile(n = 1 + 2, a)), a = c(1, 3, 2, 3, 1),
-    expected = list(c(1L, 2L, 2L, 3L, 1L))
-  )
 })
 
 test_that("hybrid handlers don't nest", {
@@ -737,4 +488,268 @@ test_that("hybrid handlers don't nest", {
     list(lag(cume_dist(a))), a = 1:4,
     expected = list(c(NA, 0.25, 0.5, 0.75))
   )
+})
+
+test_that("constant folding and argument matching in hybrid evaluator (#2299)", {
+  skip("Currently failing")
+  skip("Currently failing (external var)")
+  c <- 1:3
+  check_not_hybrid_result(
+    n_distinct(c), a = 1:5,
+    expected = 3L, test_eval = FALSE
+  )
+  check_not_hybrid_result(
+    n_distinct(a, c), a = 1:3,
+    expected = 3L, test_eval = FALSE
+  )
+  check_not_hybrid_result(
+    n_distinct(a, b, na.rm = 1), a = rep(1L, 3), b = c(1, 1, NA),
+    expected = 1L
+  )
+
+  skip("Currently failing (constfold)")
+  check_hybrid_result(
+    list(a %in% 1:3), a = 2:4,
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
+  check_hybrid_result(
+    list(a %in% as.numeric(1:3)), a = as.numeric(2:4),
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
+  check_hybrid_result(
+    list(a %in% letters[1:3]), a = letters[2:4],
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
+  check_hybrid_result(
+    list(a %in% c(TRUE, FALSE)), a = c(TRUE, FALSE, NA),
+    expected = list(c(TRUE, TRUE, FALSE))
+  )
+
+  skip("Currently failing")
+  check_hybrid_result(
+    list(a %in% NA_integer_), a = c(2:4, NA),
+    expected = list(c(FALSE, FALSE, FALSE, TRUE))
+  )
+  check_hybrid_result(
+    list(a %in% NA_real_), a = as.numeric(c(2:4, NA)),
+    expected = list(c(FALSE, FALSE, FALSE, TRUE))
+  )
+  check_hybrid_result(
+    list(a %in% NA_character_), a = c(letters[2:4], NA),
+    expected = list(c(FALSE, FALSE, FALSE, TRUE))
+  )
+  check_hybrid_result(
+    list(a %in% NA), a = c(TRUE, FALSE, NA),
+    expected = list(c(FALSE, FALSE, TRUE))
+  )
+
+  skip("Currently failing (constfold)")
+  check_hybrid_result(
+    min(a, na.rm = (1 == 0)), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    max(a, na.rm = (1 == 0)), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    min(a, na.rm = (1 == 1)), a = c(1:5, NA),
+    expected = 1L
+  )
+  check_hybrid_result(
+    max(a, na.rm = (1 == 1)), a = c(1:5, NA),
+    expected = 5L
+  )
+
+  check_hybrid_result(
+    min(a, na.rm = pi != pi), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    max(a, na.rm = pi != pi), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    min(a, na.rm = pi == pi), a = c(1:5, NA),
+    expected = 1L
+  )
+  check_hybrid_result(
+    max(a, na.rm = pi == pi), a = c(1:5, NA),
+    expected = 5L
+  )
+
+  skip("Currently failing")
+  check_hybrid_result(
+    min(a, na.rm = F), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    max(a, na.rm = F), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    min(a, na.rm = T), a = c(1:5, NA),
+    expected = 1L
+  )
+  check_hybrid_result(
+    max(a, na.rm = T), a = c(1:5, NA),
+    expected = 5L
+  )
+
+  skip("Currently failing (constfold)")
+  check_hybrid_result(
+    nth(a, 1 + 2), a = letters[1:5],
+    expected = "c"
+  )
+
+  check_hybrid_result(
+    nth(a, -4), a = 1:5,
+    expected = 2L
+  )
+
+  skip("Currently failing (constfold)")
+  check_hybrid_result(
+    list(lead(a, 1L + 2L)), a = 1:5,
+    expected = list(c(4:5, NA, NA, NA))
+  )
+  check_hybrid_result(
+    list(lag(a, 4L - 2L)), a = as.numeric(1:5),
+    expected = list(c(NA, NA, as.numeric(1:3)))
+  )
+
+  check_not_hybrid_result(
+    list(lead(a, default = 2 + 4)), a = 1:5,
+    expected = list(as.numeric(2:6))
+  )
+  check_not_hybrid_result(
+    list(lag(a, default = 3L - 3L)), a = as.numeric(1:5),
+    expected = list(as.numeric(0:4))
+  )
+
+  check_hybrid_result(
+    list(lead(a, 1 + 2)), a = 1:5,
+    expected = list(c(4:5, NA, NA, NA))
+  )
+  check_hybrid_result(
+    list(lag(a, 4 - 2)), a = as.numeric(1:5),
+    expected = list(c(NA, NA, as.numeric(1:3)))
+  )
+
+  check_hybrid_result(
+    list(lead(a, default = 2L + 4L)), a = 1:5,
+    expected = list(2:6)
+  )
+  check_hybrid_result(
+    list(lag(a, default = 3L - 3L)), a = 1:5,
+    expected = list(0:4)
+  )
+
+  check_hybrid_result(
+    list(lead(a, def = 2L + 4L)), a = 1:5,
+    expected = list(2:6)
+  )
+  check_hybrid_result(
+    list(lag(a, def = 3L - 3L)), a = 1:5,
+    expected = list(0:4)
+  )
+
+  check_hybrid_result(
+    list(lead(a, 2, 2L + 4L)), a = 1:5,
+    expected = list(c(3:6, 6L))
+  )
+  check_hybrid_result(
+    list(lag(a, 3, 3L - 3L)), a = 1:5,
+    expected = list(c(0L, 0L, 0:2))
+  )
+
+  skip("Currently failing")
+  check_hybrid_result(
+    mean(a, na.rm = (1 == 0)), a = c(1:5, NA),
+    expected = NA_real_
+  )
+  check_hybrid_result(
+    var(a, na.rm = (1 == 0)), a = c(1:3, NA),
+    expected = NA_real_
+  )
+  check_hybrid_result(
+    sd(a, na.rm = (1 == 0)), a = c(1:3, NA),
+    expected = NA_real_
+  )
+  check_hybrid_result(
+    sum(a, na.rm = (1 == 0)), a = c(1:5, NA),
+    expected = NA_integer_
+  )
+  check_hybrid_result(
+    sum(a, na.rm = (1 == 0)), a = c(as.numeric(1:5), NA),
+    expected = NA_real_
+  )
+
+  check_hybrid_result(
+    mean(a, na.rm = (1 == 1)), a = c(1:5, NA),
+    expected = 3
+  )
+  check_hybrid_result(
+    var(a, na.rm = (1 == 1)), a = c(1:3, NA),
+    expected = 1
+  )
+  check_hybrid_result(
+    sd(a, na.rm = (1 == 1)), a = c(1:3, NA),
+    expected = 1
+  )
+  check_hybrid_result(
+    sum(a, na.rm = (1 == 1)), a = c(1:5, NA),
+    expected = 15L
+  )
+  check_hybrid_result(
+    sum(a, na.rm = (1 == 1)), a = c(as.numeric(1:5), NA),
+    expected = 15
+  )
+
+  check_hybrid_result(
+    mean(na.rm = (1 == 1), a), a = c(1:5, NA),
+    expected = 3
+  )
+  check_hybrid_result(
+    var(na.rm = (1 == 1), a), a = c(1:3, NA),
+    expected = 1
+  )
+  check_hybrid_result(
+    sd(na.rm = (1 == 1), a), a = c(1:3, NA),
+    expected = 1
+  )
+  check_hybrid_result(
+    sum(na.rm = (1 == 1), a), a = c(1:5, NA),
+    expected = 15L
+  )
+  check_hybrid_result(
+    sum(na.rm = (1 == 1), a), a = c(as.numeric(1:5), NA),
+    expected = 15
+  )
+
+  skip("Currently failing (constfold)")
+  check_hybrid_result(
+    list(ntile(a, 1 + 2)), a = c(1, 3, 2, 3, 1),
+    expected = list(c(1L, 2L, 2L, 3L, 1L))
+  )
+  check_hybrid_result(
+    list(ntile(a, 1L + 2L)), a = c(1, 3, 2, 3, 1),
+    expected = list(c(1L, 2L, 2L, 3L, 1L))
+  )
+  check_hybrid_result(
+    list(ntile(n = 1 + 2, a)), a = c(1, 3, 2, 3, 1),
+    expected = list(c(1L, 2L, 2L, 3L, 1L))
+  )
+
+  skip("Currently failing")
+  df <- data_frame(x = c(NA, 1L, 2L, NA, 3L, 4L, NA))
+  expected <- rep(4L, nrow(df))
+
+  expect_equal(mutate(df, y = last(na.omit(x)))$y,           expected)
+  expect_equal(mutate(df, y = last(x[!is.na(x)]))$y,         expected)
+  expect_equal(mutate(df, y = x %>% na.omit() %>% last())$y, expected)
+  expect_equal(mutate(df, y = x %>% na.omit %>% last)$y,     expected)
+
+  data_frame(x = c(1, 1)) %>%
+    mutate(y = 1) %>%
+    summarise(z = first(x, order_by = y))
 })

--- a/tests/testthat/test-if-else.R
+++ b/tests/testthat/test-if-else.R
@@ -42,31 +42,31 @@ test_that("works with lists", {
   )
 })
 
-test_that("gives proper error messages for factor class (#2197)", {
+test_that("better factor support (#2197)", {
   skip("Currently failing")
 
-  x <- factor(1:3, labels = letters[1:3])
+  test_that("gives proper error messages for factor class (#2197)", {
+    x <- factor(1:3, labels = letters[1:3])
 
-  expect_error(if_else(x == "a", "b", x), "`false` has class factor not character")
-  expect_error(if_else(x == "a", 1L, x), "`false` has class factor not integer")
-  expect_error(if_else(x == "a", 1., x), "`false` has class factor not numeric")
-  expect_error(if_else(x == "a", TRUE, x), "`false` has class factor not logical")
-  expect_error(if_else(x == "a", Sys.Date(), x), "`false` has class factor not Date")
+    expect_error(if_else(x == "a", "b", x), "`false` has class factor not character")
+    expect_error(if_else(x == "a", 1L, x), "`false` has class factor not integer")
+    expect_error(if_else(x == "a", 1., x), "`false` has class factor not numeric")
+    expect_error(if_else(x == "a", TRUE, x), "`false` has class factor not logical")
+    expect_error(if_else(x == "a", Sys.Date(), x), "`false` has class factor not Date")
 
-  expect_error(if_else(x == "a", x, "b"), "`false` has class character not factor")
-  expect_error(if_else(x == "a", x, 1L), "`false` has class integer not factor")
-  expect_error(if_else(x == "a", x, 1.), "`false` has class numeric not factor")
-  expect_error(if_else(x == "a", x, TRUE), "`false` has class logical not factor")
-  expect_error(if_else(x == "a", x, Sys.Date()), "`false` has class Date not factor")
-})
+    expect_error(if_else(x == "a", x, "b"), "`false` has class character not factor")
+    expect_error(if_else(x == "a", x, 1L), "`false` has class integer not factor")
+    expect_error(if_else(x == "a", x, 1.), "`false` has class numeric not factor")
+    expect_error(if_else(x == "a", x, TRUE), "`false` has class logical not factor")
+    expect_error(if_else(x == "a", x, Sys.Date()), "`false` has class Date not factor")
+  })
 
-test_that("works with factors as both `true` and `false` (#2197)", {
-  skip("Currently failing")
+  test_that("works with factors as both `true` and `false` (#2197)", {
+    x <- factor(1:3, labels = letters[1:3])
+    y <- factor(1:3, labels = letters[c(1, 2, 4)])
 
-  x <- factor(1:3, labels = letters[1:3])
-  y <- factor(1:3, labels = letters[c(1, 2, 4)])
+    expect_equal(if_else(x == "a", x[[2]], x), x[c(2, 2, 3)])
 
-  expect_equal(if_else(x == "a", x[[2]], x), x[c(2, 2, 3)])
-
-  expect_error(if_else(x == "a", x, y), "levels in `false` don't match levels in `true`")
+    expect_error(if_else(x == "a", x, y), "levels in `false` don't match levels in `true`")
+  })
 })

--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -38,22 +38,3 @@ test_that("firsts uses default value for 0 length augmented vectors", {
   expect_equal(first(dt[0]), dt[NA])
   expect_equal(first(tm[0]), tm[NA])
 })
-
-test_that("last as part of a compound expression works within mutate (#2090)", {
-  skip("Currently failing")
-
-  df <- data_frame(x = c(NA, 1L, 2L, NA, 3L, 4L, NA))
-  expected <- rep(4L, nrow(df))
-
-  expect_equal(mutate(df, y = last(na.omit(x)))$y,           expected)
-  expect_equal(mutate(df, y = last(x[!is.na(x)]))$y,         expected)
-  expect_equal(mutate(df, y = x %>% na.omit() %>% last())$y, expected)
-  expect_equal(mutate(df, y = x %>% na.omit %>% last)$y,     expected)
-})
-
-test_that("nth and order_by doesn't crash (#2166)", {
-  skip("Currently failing")
-  data_frame(x = c(1, 1)) %>%
-    mutate(y = 1) %>%
-    summarise(z = first(x, order_by = y))
-})

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -49,6 +49,12 @@ test_that("order_by() returns correct value", {
 
 test_that("order_by() works in arbitrary envs (#2297)", {
   env <- child_env("base")
-  with_env(env, dplyr::order_by(5:1, cumsum(1:5)))
-  order_by(5:1, cumsum(1:5))
+  expect_equal(
+    with_env(env, dplyr::order_by(5:1, cumsum(1:5))),
+    rev(cumsum(rev(1:5)))
+  )
+  expect_equal(
+    order_by(5:1, cumsum(1:5)),
+    rev(cumsum(rev(1:5)))
+  )
 })


### PR DESCRIPTION
Now only two remaining. We could also move them to the corresponding GitHub issues.